### PR TITLE
Adding support for building Carrot as a shared library on Windows

### DIFF
--- a/include/carrot/block.hpp
+++ b/include/carrot/block.hpp
@@ -10,6 +10,8 @@
 #include <carrot/style.hpp>
 #include <carrot/target_info.hpp>
 
+#include "carrot_export.hpp"
+
 #include <array>
 #include <memory>
 #include <string>
@@ -24,7 +26,7 @@ namespace carrot
 class style;
 
 template <typename T>
-class block_base
+class CARROT_EXPORT block_base
 {
 public:
     block_base() = default;
@@ -57,11 +59,11 @@ private:
 };
 
 template <typename T>
-struct is_block : std::is_base_of<block_base<T>, T>
+struct CARROT_EXPORT is_block : std::is_base_of<block_base<T>, T>
 {
 };
 
-class block
+class CARROT_EXPORT block
 {
 public:
     block();
@@ -164,12 +166,12 @@ private:
     std::unique_ptr<block_interface> self_;
 };
 
-block operator<<(block lhs, block rhs);
+CARROT_EXPORT block operator<<(block lhs, block rhs);
 
 class plain_form;
 
-void render(const block& root, plain_form& output_form);
-void render(const block& root, plain_form& output_form, const style& s);
+CARROT_EXPORT void render(const block& root, plain_form& output_form);
+CARROT_EXPORT void render(const block& root, plain_form& output_form, const style& s);
 } // namespace carrot
 
 #endif

--- a/include/carrot/caret_block.hpp
+++ b/include/carrot/caret_block.hpp
@@ -9,12 +9,14 @@
 #include <carrot/block.hpp>
 #include <carrot/color.hpp>
 
+#include "carrot_export.hpp"
+
 namespace carrot
 {
 
 class style;
 
-class caret_block final : public block_base<caret_block>
+class CARROT_EXPORT caret_block final : public block_base<caret_block>
 {
 public:
     caret_block(block marked_block_, long int pos_);
@@ -29,8 +31,8 @@ private:
     long int pos_;
 };
 
-caret_block mark_with_caret(block marked_block, long int caret_position);
-caret_block mark_with_caret(block marked_block, long int caret_position, std::vector<std::string> tags);
+CARROT_EXPORT caret_block mark_with_caret(block marked_block, long int caret_position);
+CARROT_EXPORT caret_block mark_with_caret(block marked_block, long int caret_position, std::vector<std::string> tags);
 }
 
 #endif

--- a/include/carrot/caret_underline_block.hpp
+++ b/include/carrot/caret_underline_block.hpp
@@ -9,10 +9,12 @@
 #include <carrot/block.hpp>
 #include <carrot/color.hpp>
 
+#include "carrot_export.hpp"
+
 namespace carrot
 {
 
-class caret_underline_block final : public block_base<caret_underline_block>
+class CARROT_EXPORT caret_underline_block final : public block_base<caret_underline_block>
 {
 public:
     caret_underline_block(block underlined_element_, long int pos_);
@@ -27,9 +29,11 @@ private:
     long int pos_;
 };
 
-caret_underline_block underline_with_caret(block underlined_block, long int caret_position);
-caret_underline_block underline_with_caret(block underlined_block, long int caret_position,
-                                           std::vector<std::string> tags);
-}
+CARROT_EXPORT caret_underline_block underline_with_caret(block underlined_block,
+                                                         long int caret_position);
+CARROT_EXPORT caret_underline_block underline_with_caret(block underlined_block,
+                                                         long int caret_position,
+                                                         std::vector<std::string> tags);
+} // namespace carrot
 
 #endif

--- a/include/carrot/checkbox_list_block.hpp
+++ b/include/carrot/checkbox_list_block.hpp
@@ -7,15 +7,16 @@
 #define CARROT_CHECKBOX_BLOCK_HPP
 
 #include <carrot/grid_block.hpp>
-
 #include <carrot/block.hpp>
+
+#include "carrot_export.hpp"
 
 #include <string>
 
 namespace carrot
 {
 
-class checkbox_list_block final : public block_base<checkbox_list_block>
+class CARROT_EXPORT checkbox_list_block final : public block_base<checkbox_list_block>
 {
 public:
     checkbox_list_block();
@@ -28,7 +29,7 @@ private:
     grid_block grid_;
 };
 
-checkbox_list_block make_checkbox_list();
+CARROT_EXPORT checkbox_list_block make_checkbox_list();
 
 }
 

--- a/include/carrot/color.hpp
+++ b/include/carrot/color.hpp
@@ -8,6 +8,8 @@
 
 #include <carrot/exception.hpp>
 
+#include "carrot_export.hpp"
+
 #include <boost/variant.hpp>
 
 #include <array>
@@ -17,7 +19,7 @@
 
 namespace carrot
 {
-class invalid_color_error : public virtual exception, public virtual std::runtime_error
+class CARROT_EXPORT invalid_color_error : public virtual exception, public virtual std::runtime_error
 {
 public:
     explicit invalid_color_error(std::string message_)
@@ -26,11 +28,11 @@ public:
     }
 };
 
-class default_color
+class CARROT_EXPORT default_color
 {
 };
 
-class rgb_color
+class CARROT_EXPORT rgb_color
 {
 public:
     constexpr rgb_color(short red_, short green_, short blue_) noexcept
@@ -59,7 +61,7 @@ private:
     short blue_;
 };
 
-class hsl_color
+class CARROT_EXPORT hsl_color
 {
 public:
     constexpr hsl_color(float hue_, float saturation_, float lightness_) noexcept
@@ -88,7 +90,7 @@ private:
     float lightness_;
 };
 
-class named_color
+class CARROT_EXPORT named_color
 {
 public:
     explicit named_color(std::string name_) : name_(std::move(name_))
@@ -106,7 +108,7 @@ private:
 
 using color = boost::variant<default_color, rgb_color, hsl_color, named_color>;
 
-class color_table
+class CARROT_EXPORT color_table
 {
 public:
     color_table& add_color(std::string name, color c);
@@ -117,25 +119,25 @@ private:
     std::unordered_map<std::string, color> color_map_;
 };
 
-color_table get_default_color_table();
+CARROT_EXPORT color_table get_default_color_table();
 
-rgb_color rgb(const color& c, const color_table& ctable);
-rgb_color rgb(const color& c);
-rgb_color rgb(rgb_color c);
+CARROT_EXPORT rgb_color rgb(const color& c, const color_table& ctable);
+CARROT_EXPORT rgb_color rgb(const color& c);
+CARROT_EXPORT rgb_color rgb(rgb_color c);
 
-hsl_color hsl(const color& c, const color_table& ctable);
-hsl_color hsl(const color& c);
-hsl_color hsl(hsl_color c);
+CARROT_EXPORT hsl_color hsl(const color& c, const color_table& ctable);
+CARROT_EXPORT hsl_color hsl(const color& c);
+CARROT_EXPORT hsl_color hsl(hsl_color c);
 
-color canonicalize(const color& c, const color_table& ctable);
+CARROT_EXPORT color canonicalize(const color& c, const color_table& ctable);
 
-float distance(const color& color1, const color& color2);
+CARROT_EXPORT float distance(const color& color1, const color& color2);
 
-color get_default_color();
+CARROT_EXPORT color get_default_color();
 
-bool is_default_color(const color& c);
+CARROT_EXPORT bool is_default_color(const color& c);
 
-const std::array<hsl_color, 256>& get_xterm_color_table();
+CARROT_EXPORT const std::array<hsl_color, 256>& get_xterm_color_table();
 }
 
 #endif

--- a/include/carrot/color_map.hpp
+++ b/include/carrot/color_map.hpp
@@ -9,6 +9,8 @@
 #include <carrot/color.hpp>
 #include <carrot/exception.hpp>
 
+#include "carrot_export.hpp"
+
 #include <boost/range/any_range.hpp>
 
 #include <vector>
@@ -17,7 +19,7 @@
 namespace carrot
 {
 
-class invalid_color_map_error : public virtual exception, public virtual std::runtime_error
+class CARROT_EXPORT invalid_color_map_error : public virtual exception, public virtual std::runtime_error
 {
 public:
     explicit invalid_color_map_error(std::string message_)
@@ -26,7 +28,7 @@ public:
     }
 };
 
-class color_map
+class CARROT_EXPORT color_map
 {
 public:
     template<typename Colors>

--- a/include/carrot/empty_block.hpp
+++ b/include/carrot/empty_block.hpp
@@ -8,17 +8,19 @@
 
 #include <carrot/block.hpp>
 
+#include "carrot_export.hpp"
+
 namespace carrot
 {
 
-class empty_block final : public block_base<empty_block>
+class CARROT_EXPORT empty_block final : public block_base<empty_block>
 {
 public:
     void render(form & output_form, const style& s) const;
     std::array<long int, 2> extent(const target_info& output_target, const style& s) const;
 };
 
-block make_empty();
+CARROT_EXPORT block make_empty();
 }
 
 #endif

--- a/include/carrot/exception.hpp
+++ b/include/carrot/exception.hpp
@@ -6,17 +6,19 @@
 #ifndef CARROT_EXCEPTION_HPP
 #define CARROT_EXCEPTION_HPP
 
+#include "carrot_export.hpp"
+
 #include <exception>
 #include <stdexcept>
 
 namespace carrot
 {
 
-class exception : public std::exception
+class CARROT_EXPORT exception : public std::exception
 {
 };
 
-class runtime_error : public virtual exception, public virtual std::runtime_error
+class CARROT_EXPORT runtime_error : public virtual exception, public virtual std::runtime_error
 {
     using std::runtime_error::runtime_error;
 };

--- a/include/carrot/form.hpp
+++ b/include/carrot/form.hpp
@@ -7,15 +7,16 @@
 #define CARROT_FORM_HPP
 
 #include <carrot/glyph.hpp>
-
 #include <carrot/target_info.hpp>
+
+#include "carrot_export.hpp"
 
 #include <boost/multi_array.hpp>
 
 namespace carrot
 {
 
-class form
+class CARROT_EXPORT form
 {
 public:
     form() = default;

--- a/include/carrot/form_view.hpp
+++ b/include/carrot/form_view.hpp
@@ -8,10 +8,12 @@
 
 #include <carrot/form.hpp>
 
+#include "carrot_export.hpp"
+
 namespace carrot
 {
 
-class form_view final : public form
+class CARROT_EXPORT form_view final : public form
 {
 public:
     form_view(form & base_form_, long int row_offset_, long int column_offset_);

--- a/include/carrot/frame_block.hpp
+++ b/include/carrot/frame_block.hpp
@@ -8,10 +8,12 @@
 
 #include <carrot/block.hpp>
 
+#include "carrot_export.hpp"
+
 namespace carrot
 {
 
-class frame_block final : public block_base<frame_block>
+class CARROT_EXPORT frame_block final : public block_base<frame_block>
 {
 public:
     explicit frame_block(block framed_block_, long int margin_ = 1);
@@ -25,7 +27,7 @@ private:
     long int margin_;
 };
 
-frame_block frame(block framed_block, long int margin = 1);
+CARROT_EXPORT frame_block frame(block framed_block, long int margin = 1);
 
 }
 

--- a/include/carrot/glyph.hpp
+++ b/include/carrot/glyph.hpp
@@ -8,13 +8,15 @@
 
 #include <carrot/color.hpp>
 
+#include "carrot_export.hpp"
+
 #include <string>
 #include <string_view>
 
 namespace carrot
 {
 
-struct glyph
+struct CARROT_EXPORT glyph
 {
     glyph();
 

--- a/include/carrot/grid_block.hpp
+++ b/include/carrot/grid_block.hpp
@@ -13,6 +13,8 @@
 
 #include <carrot/block.hpp>
 
+#include "carrot_export.hpp"
+
 #include <boost/multi_array.hpp>
 
 #include <tuple>
@@ -21,7 +23,7 @@
 namespace carrot
 {
 
-class grid_block final : public block_base<grid_block>
+class CARROT_EXPORT grid_block final : public block_base<grid_block>
 {
 public:
     grid_block(long int rows_, long int columns_);
@@ -48,7 +50,7 @@ private:
     boost::multi_array<block, 2> blocks_;
 };
 
-grid_block make_grid(long int rows, long int columns);
+CARROT_EXPORT grid_block make_grid(long int rows, long int columns);
 } // namespace carrot
 
 #endif

--- a/include/carrot/indent_block.hpp
+++ b/include/carrot/indent_block.hpp
@@ -8,10 +8,12 @@
 
 #include <carrot/block.hpp>
 
+#include "carrot_export.hpp"
+
 namespace carrot
 {
 
-class indent_block final : public block_base<indent_block>
+class CARROT_EXPORT indent_block final : public block_base<indent_block>
 {
 public:
     indent_block(block indented_block_, long int indent_levels_);
@@ -25,10 +27,10 @@ private:
     long int indent_levels_;
 };
 
-indent_block indent(block indented_block, long int indent_levels = 1);
+CARROT_EXPORT indent_block indent(block indented_block, long int indent_levels = 1);
 
-indent_block indent(block indented_block, std::vector<std::string> tags);
-indent_block indent(block indented_block, long int indent_levels, std::vector<std::string> tags);
+CARROT_EXPORT indent_block indent(block indented_block, std::vector<std::string> tags);
+CARROT_EXPORT indent_block indent(block indented_block, long int indent_levels, std::vector<std::string> tags);
 
 }
 

--- a/include/carrot/irregular_grid_block.hpp
+++ b/include/carrot/irregular_grid_block.hpp
@@ -8,12 +8,14 @@
 
 #include <carrot/block.hpp>
 
+#include "carrot_export.hpp"
+
 #include <vector>
 
 namespace carrot
 {
 
-class irregular_grid_block final : public block_base<irregular_grid_block>
+class CARROT_EXPORT irregular_grid_block final : public block_base<irregular_grid_block>
 {
 public:
     class row
@@ -39,7 +41,7 @@ private:
     std::vector<row> rows_;
 };
 
-irregular_grid_block make_irregular_grid();
+CARROT_EXPORT irregular_grid_block make_irregular_grid();
 }
 
 #endif

--- a/include/carrot/line_block.hpp
+++ b/include/carrot/line_block.hpp
@@ -8,19 +8,21 @@
 
 #include <carrot/block.hpp>
 
+#include "carrot_export.hpp"
+
 #include <vector>
 #include <utility>
 
 namespace carrot
 {
 
-enum class growth_direction
+enum class CARROT_EXPORT growth_direction
 {
     down,
     right
 };
 
-class line_block final : public block_base<line_block>
+class CARROT_EXPORT line_block final : public block_base<line_block>
 {
 public:
     explicit line_block(growth_direction direction_);
@@ -34,10 +36,10 @@ private:
     std::vector<block> blocks_;
 };
 
-line_block make_line(growth_direction direction);
+CARROT_EXPORT line_block make_line(growth_direction direction);
 
 template<typename... Blocks>
-line_block connect(Blocks... blocks)
+CARROT_EXPORT line_block connect(Blocks... blocks)
 {
     auto line = line_block(growth_direction::right);
 

--- a/include/carrot/list_block.hpp
+++ b/include/carrot/list_block.hpp
@@ -7,13 +7,14 @@
 #define CARROT_LIST_BLOCK_HPP
 
 #include <carrot/grid_block.hpp>
-
 #include <carrot/block.hpp>
+
+#include "carrot_export.hpp"
 
 namespace carrot
 {
 
-class list_block final : public block_base<list_block>
+class CARROT_EXPORT list_block final : public block_base<list_block>
 {
 public:
     list_block();
@@ -27,7 +28,7 @@ private:
     grid_block grid_;
 };
 
-list_block make_list();
+CARROT_EXPORT list_block make_list();
 
 }
 

--- a/include/carrot/placeholder_block.hpp
+++ b/include/carrot/placeholder_block.hpp
@@ -8,10 +8,12 @@
 
 #include <carrot/block.hpp>
 
+#include "carrot_export.hpp"
+
 namespace carrot
 {
 
-class placeholder_block final : public block_base<placeholder_block>
+class CARROT_EXPORT placeholder_block final : public block_base<placeholder_block>
 {
 public:
     explicit placeholder_block(std::vector<std::string> flags_);
@@ -21,7 +23,7 @@ public:
     std::array<long int, 2> extent(const target_info& output_target, const style& s) const;
 };
 
-placeholder_block placeholder(std::vector<std::string> flags);
+CARROT_EXPORT placeholder_block placeholder(std::vector<std::string> flags);
 
 }
 

--- a/include/carrot/plain_form.hpp
+++ b/include/carrot/plain_form.hpp
@@ -9,11 +9,13 @@
 #include <carrot/form.hpp>
 #include <carrot/target_info.hpp>
 
+#include "carrot_export.hpp"
+
 #include <string>
 
 namespace carrot
 {
-class plain_form final : public form
+class CARROT_EXPORT plain_form final : public form
 {
 public:
     plain_form(target_info target_, long int rows_ = 0, long int columns_ = 0);

--- a/include/carrot/progress_bar_block.hpp
+++ b/include/carrot/progress_bar_block.hpp
@@ -7,13 +7,14 @@
 #define CARROT_PROGRESS_BAR_BLOCK_HPP
 
 #include <carrot/text_block.hpp>
-
 #include <carrot/block.hpp>
+
+#include "carrot_export.hpp"
 
 namespace carrot
 {
 
-class progress_bar_block final : public block_base<progress_bar_block>
+class CARROT_EXPORT progress_bar_block final : public block_base<progress_bar_block>
 {
 public:
     explicit progress_bar_block(long int progress_);
@@ -25,7 +26,7 @@ private:
     text_block text_;
 };
 
-progress_bar_block progress_bar(long int progress);
+CARROT_EXPORT progress_bar_block progress_bar(long int progress);
 }
 
 #endif

--- a/include/carrot/style.hpp
+++ b/include/carrot/style.hpp
@@ -9,6 +9,8 @@
 #include <carrot/color.hpp>
 #include <carrot/exception.hpp>
 
+#include "carrot_export.hpp"
+
 #include <boost/variant.hpp>
 
 #include <memory>
@@ -21,7 +23,7 @@
 namespace carrot
 {
 
-class missing_style_info_error : public virtual exception, public virtual std::runtime_error
+class CARROT_EXPORT missing_style_info_error : public virtual exception, public virtual std::runtime_error
 {
 public:
     explicit missing_style_info_error()
@@ -30,7 +32,7 @@ public:
     }
 };
 
-class mismatched_attribute_type_error : public virtual exception, public virtual std::runtime_error
+class CARROT_EXPORT mismatched_attribute_type_error : public virtual exception, public virtual std::runtime_error
 {
 public:
     explicit mismatched_attribute_type_error(std::string attribute_id_)
@@ -40,7 +42,7 @@ public:
     }
 };
 
-class style_rule
+class CARROT_EXPORT style_rule
 {
 public:
     struct attribute
@@ -106,7 +108,7 @@ private:
     std::vector<std::pair<std::string, attribute>> attributes_;
 };
 
-class style
+class CARROT_EXPORT style
 {
 public:
     using integer = style_rule::integer;
@@ -133,7 +135,7 @@ public:
     }
 };
 
-class user_defined_style final : public style
+class CARROT_EXPORT user_defined_style final : public style
 {
 public:
     user_defined_style() = default;
@@ -153,7 +155,7 @@ private:
     std::unique_ptr<style> base_style_;
 };
 
-class augmented_style final : public style
+class CARROT_EXPORT augmented_style final : public style
 {
 public:
     explicit augmented_style(const style& base_style_);
@@ -172,7 +174,7 @@ private:
     const style* base_style_;
 };
 
-std::unique_ptr<style> get_default_style();
+CARROT_EXPORT std::unique_ptr<style> get_default_style();
 }
 
 #endif

--- a/include/carrot/table_block.hpp
+++ b/include/carrot/table_block.hpp
@@ -7,9 +7,10 @@
 #define CARROT_TABLE_BLOCK_HPP
 
 #include <carrot/grid_block.hpp>
-
 #include <carrot/block.hpp>
 #include <carrot/exception.hpp>
+
+#include "carrot_export.hpp"
 
 #include <stdexcept>
 #include <vector>
@@ -17,7 +18,7 @@
 namespace carrot
 {
 
-class invalid_number_of_columns_error : public virtual exception, public virtual std::logic_error
+class CARROT_EXPORT invalid_number_of_columns_error : public virtual exception, public virtual std::logic_error
 {
 public:
     invalid_number_of_columns_error(long int expected, long int provided);
@@ -38,7 +39,7 @@ private:
     long int columns_;
 };
 
-table_block make_table(long int columns);
+CARROT_EXPORT table_block make_table(long int columns);
 }
 
 #endif

--- a/include/carrot/target_info.hpp
+++ b/include/carrot/target_info.hpp
@@ -8,19 +8,21 @@
 
 #include <carrot/exception.hpp>
 
+#include "carrot_export.hpp"
+
 #include <locale>
 #include <stdexcept>
 
 namespace carrot
 {
 
-class invalid_target_error : public virtual exception, public virtual std::logic_error
+class CARROT_EXPORT invalid_target_error : public virtual exception, public virtual std::logic_error
 {
 public:
     explicit invalid_target_error(const std::string& reason_);
 };
 
-class target_info
+class CARROT_EXPORT target_info
 {
 public:
     target_info(std::locale locale_, bool supports_colorized_output_, long int tab_width_);
@@ -35,14 +37,14 @@ private:
     long int tab_width_;
 };
 
-target_info get_stdout_target(long int tab_width = 4);
-target_info get_stdout_target(std::locale locale, long int tab_width = 4);
+CARROT_EXPORT target_info get_stdout_target(long int tab_width = 4);
+CARROT_EXPORT target_info get_stdout_target(std::locale locale, long int tab_width = 4);
 
-target_info get_file_target(long int tab_width = 4);
-target_info get_file_target(std::locale locale, long int tab_width = 4);
+CARROT_EXPORT target_info get_file_target(long int tab_width = 4);
+CARROT_EXPORT target_info get_file_target(std::locale locale, long int tab_width = 4);
 
-target_info get_colorized_target(long int tab_width = 4);
-target_info get_colorized_target(std::locale locale, long int tab_width = 4);
+CARROT_EXPORT target_info get_colorized_target(long int tab_width = 4);
+CARROT_EXPORT target_info get_colorized_target(std::locale locale, long int tab_width = 4);
 
 }
 

--- a/include/carrot/text_block.hpp
+++ b/include/carrot/text_block.hpp
@@ -7,8 +7,9 @@
 #define CARROT_TEXT_BLOCK_HPP
 
 #include <carrot/block.hpp>
-
 #include <carrot/color.hpp>
+
+#include "carrot_export.hpp"
 
 #include <vector>
 #include <string>
@@ -16,7 +17,7 @@
 namespace carrot
 {
 
-class text_block final : public block_base<text_block>
+class CARROT_EXPORT text_block final : public block_base<text_block>
 {
 public:
     explicit text_block(const std::string& content_);
@@ -30,8 +31,8 @@ private:
     std::vector<std::string> rows_;
 };
 
-text_block text(const std::string& content);
-text_block text(const std::string& content, std::vector<std::string> tags);
+CARROT_EXPORT text_block text(const std::string& content);
+CARROT_EXPORT text_block text(const std::string& content, std::vector<std::string> tags);
 
 }
 

--- a/include/carrot/underline_block.hpp
+++ b/include/carrot/underline_block.hpp
@@ -8,10 +8,12 @@
 
 #include <carrot/block.hpp>
 
+#include "carrot_export.hpp"
+
 namespace carrot
 {
 
-class underline_block final : public block_base<underline_block>
+class CARROT_EXPORT underline_block final : public block_base<underline_block>
 {
 public:
     explicit underline_block(block underlined_element_);
@@ -25,8 +27,8 @@ private:
     block underlined_element_;
 };
 
-underline_block underline(block underlined_element);
-underline_block underline(block underlined_element, std::vector<std::string> tags);
+CARROT_EXPORT underline_block underline(block underlined_element);
+CARROT_EXPORT underline_block underline(block underlined_element, std::vector<std::string> tags);
 }
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,8 +29,12 @@ target_compile_features(carrot PUBLIC cxx_std_17)
 target_include_directories(carrot PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include> ${Boost_INCLUDE_DIRS})
 target_link_libraries(carrot PUBLIC ${Boost_LIBRARIES} PRIVATE Boost::disable_autolinking)
 target_compile_options(carrot PRIVATE ${LTO_CXX_OPTIONS})
-set_target_properties(carrot PROPERTIES LINK_FLAGS "${LTO_CXX_OPTIONS}")
+target_link_libraries(carrot PRIVATE "${LTO_CXX_OPTIONS}")
 set_target_properties(carrot PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+generate_export_header(carrot EXPORT_FILE_NAME carrot_export.hpp)
+target_include_directories(carrot PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+set_target_properties(carrot PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN 1)
 
 if (CURSES_FOUND)
     target_include_directories(carrot PRIVATE ${CURSES_INCLUDE_DIR})
@@ -61,6 +65,8 @@ set_property(TARGET carrot APPEND PROPERTY COMPATIBLE_INTERFACE_STRING carrot_MI
 
 install(DIRECTORY ../include DESTINATION .
         FILES_MATCHING PATTERN "*.hpp")
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/carrot_export.hpp DESTINATION ./include)
 
 install(TARGETS carrot EXPORT carrot-targets
         RUNTIME DESTINATION bin


### PR DESCRIPTION
This PR marks each part of the interface as exported.
It also sets the default visibility on Linux to "hidden".