### PR TITLE
Add an option to enable experimental features

### DIFF
--- a/include/carrot/block.hpp
+++ b/include/carrot/block.hpp
@@ -25,6 +25,14 @@ namespace carrot
 
 class style;
 
+#if __cpp_concepts >= 201507
+template <typename T>
+concept bool Block = requires (T x, form& output_form, const style& s, const target_info& ti) {
+    x.render(output_form, s);
+    x.extent(ti, s);
+};
+#endif
+
 template <typename T>
 class CARROT_EXPORT block_base
 {
@@ -68,11 +76,18 @@ class CARROT_EXPORT block
 public:
     block();
 
+#if __cpp_concepts >= 201507
+    template <Block BlockType>
+    block(BlockType self_) : self_(std::make_unique<block_wrapper<BlockType>>(std::move(self_)))
+    {
+    }
+#else
     template <typename Block,
               typename Enabler = typename std::enable_if<is_block<Block>::value>::type>
     block(Block self_) : self_(std::make_unique<block_wrapper<Block>>(std::move(self_)))
     {
     }
+#endif
 
     block(const block& other)
     {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,9 @@ option(BUILD_SHARED_LIBS "Build the library as a shared library." OFF)
 
 option(CARROT_WITH_UNICODE_SUPPORT "Enable support for Unicode." ON)
 
+option(CARROT_WITH_EXPERIMENTAL_FEATURES "Enable experimental features." OFF)
+mark_as_advanced(CARROT_WITH_EXPERIMENTAL_FEATURES)
+
 find_package(Boost 1.58.0 REQUIRED)
 
 find_package(Curses)
@@ -31,6 +34,14 @@ target_link_libraries(carrot PUBLIC ${Boost_LIBRARIES} PRIVATE Boost::disable_au
 target_compile_options(carrot PRIVATE ${LTO_CXX_OPTIONS})
 target_link_libraries(carrot PRIVATE "${LTO_CXX_OPTIONS}")
 set_target_properties(carrot PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+if (CARROT_WITH_EXPERIMENTAL_FEATURES)
+    CHECK_CXX_COMPILER_FLAG(-fconcepts COMPILER_HAS_GCC_CONCEPT_FLAG)
+
+    if (COMPILER_HAS_GCC_CONCEPT_FLAG)
+        target_compile_options(carrot PUBLIC -fconcepts)
+    endif()
+endif()
 
 generate_export_header(carrot EXPORT_FILE_NAME carrot_export.hpp)
 target_include_directories(carrot PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)


### PR DESCRIPTION
This option is off by default and should only be used to test experimental features. The code protected by this flag might randomly break.

As the first experimental feature, this PR also introduces a concept for blocks.