### PR TITLE
Allow to construct a text block from a string view

### DIFF
--- a/include/carrot/text_block.hpp
+++ b/include/carrot/text_block.hpp
@@ -12,7 +12,7 @@
 #include "carrot_export.hpp"
 
 #include <vector>
-#include <string>
+#include <string_view>
 
 namespace carrot
 {
@@ -20,8 +20,8 @@ namespace carrot
 class CARROT_EXPORT text_block final : public block_base<text_block>
 {
 public:
-    explicit text_block(const std::string& content_);
-    text_block(const std::string& content_, std::vector<std::string> tags_);
+    explicit text_block(std::string_view content_);
+    text_block(std::string_view content_, std::vector<std::string> tags_);
 
     void render(form& output_form, const style& s) const;
 
@@ -31,8 +31,8 @@ private:
     std::vector<std::string> rows_;
 };
 
-CARROT_EXPORT text_block text(const std::string& content);
-CARROT_EXPORT text_block text(const std::string& content, std::vector<std::string> tags);
+CARROT_EXPORT text_block text(std::string_view content);
+CARROT_EXPORT text_block text(std::string_view content, std::vector<std::string> tags);
 
 }
 

--- a/src/text_block.cpp
+++ b/src/text_block.cpp
@@ -26,11 +26,11 @@
 namespace carrot
 {
 
-text_block::text_block(const std::string& content_) : text_block(content_, {})
+text_block::text_block(std::string_view content_) : text_block(content_, {})
 {
 }
 
-text_block::text_block(const std::string& content_, std::vector<std::string> tags_)
+text_block::text_block(std::string_view content_, std::vector<std::string> tags_)
 : block_base<text_block>(std::move(tags_))
 {
     boost::split(rows_, content_, boost::is_any_of("\n"));
@@ -110,12 +110,12 @@ std::array<long int, 2> text_block::extent(const target_info& output_target,
     return std::array<long int, 2>{rows, columns};
 }
 
-text_block text(const std::string& content)
+text_block text(std::string_view content)
 {
     return text_block(content);
 }
 
-text_block text(const std::string& content, std::vector<std::string> flags)
+text_block text(std::string_view content, std::vector<std::string> flags)
 {
     return text_block(content, std::move(flags));
 }


### PR DESCRIPTION
As we have previously taken a reference to a string, this change is fully backward compatible and just extends the set of arguments which are natively supported.