### PR TITLE
Speeding up the handling of terminal escape sequences

### DIFF
--- a/conan/ci/linux/conanfile.txt
+++ b/conan/ci/linux/conanfile.txt
@@ -1,6 +1,7 @@
 [requires]
 boost/1.70.0@conan/stable
 icu/62.1@bincrafters/stable
+fmt/5.3.0@bincrafters/stable
 
 [generators]
 cmake_paths

--- a/conan/ci/windows/conanfile.txt
+++ b/conan/ci/windows/conanfile.txt
@@ -1,6 +1,7 @@
 [requires]
 boost/1.70.0@conan/stable
 icu/62.1@bincrafters/stable
+fmt/5.3.0@bincrafters/stable
 
 [generators]
 cmake_paths

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -9,7 +9,7 @@ class CarrotConan(ConanFile):
     description = "A C++ library for rendering expressive diagnostic messages"
     settings = "os", "compiler", "build_type", "arch"
     generators = "cmake_paths"
-    requires = "boost/1.70.0@conan/stable", "icu/62.1@bincrafters/stable"
+    requires = "boost/1.70.0@conan/stable", "icu/62.1@bincrafters/stable", "fmt/5.3.0@bincrafters/stable"
     exports_sources = "../*"
 
     def configure(self):

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ option(CARROT_WITH_EXPERIMENTAL_FEATURES "Enable experimental features." OFF)
 mark_as_advanced(CARROT_WITH_EXPERIMENTAL_FEATURES)
 
 find_package(Boost 1.58.0 REQUIRED)
+find_package(fmt REQUIRED)
 
 find_package(Curses)
 
@@ -31,7 +32,7 @@ add_library(carrot ${SOURCE_FILES} ${FULL_INCLUDE_FILES})
 target_compile_features(carrot PUBLIC cxx_std_17)
 target_include_directories(carrot PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>)
 target_include_directories(carrot SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
-target_link_libraries(carrot PUBLIC ${Boost_LIBRARIES} PRIVATE Boost::disable_autolinking)
+target_link_libraries(carrot PUBLIC ${Boost_LIBRARIES} PRIVATE Boost::disable_autolinking fmt::fmt)
 target_compile_options(carrot PRIVATE ${LTO_CXX_OPTIONS})
 target_link_libraries(carrot PRIVATE "${LTO_CXX_OPTIONS}")
 set_target_properties(carrot PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
This PR removes all allocations within the escape sequence handling except for the final rendering step and only renders the escape sequence if it has changed.

To render the terminal escape sequence, carrot relies on the new dependency {fmt}.