### PR TITLE
Documenting the error handling for each function

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 Checks: "-*,modernize-*,performance-*,readability-*,-readability-braces-around-statements,-readability-implicit-bool-conversion,
-         -readability-uppercase-literal-suffix,
+         -readability-uppercase-literal-suffix,-modernize-use-trailing-return-type,
          clang-analyzer-*,-clang-analyzer-alpha*, cppcoreguidelines-*,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,misc-*,
          -clang-analyzer-alpha.core.CastToStruct, bugprone-*,-bugprone-bool-pointer-implicit-conversion"
 CheckOptions: [{key: AllowPointerConditions, value: 1},

--- a/include/carrot/block.hpp
+++ b/include/carrot/block.hpp
@@ -46,13 +46,13 @@ class CARROT_EXPORT block_base
 public:
     /** @brief Construct a new block without any tags.
      */
-    block_base() = default;
+    block_base() noexcept = default;
 
     /** @brief Construct a new block with a list of tags.
      *
      * @param tags_ The list of applied tags.
      */
-    explicit block_base(std::vector<std::string> tags_) : block_base("", std::move(tags_))
+    explicit block_base(std::vector<std::string> tags_) noexcept : block_base("", std::move(tags_))
     {
     }
 
@@ -61,7 +61,7 @@ public:
      * @param id_ The id of the block.
      * @param tags_ The list of applied tags.
      */
-    explicit block_base(std::string id_, std::vector<std::string> tags_)
+    explicit block_base(std::string id_, std::vector<std::string> tags_) noexcept
     : id_(std::move(id_)), tags_(std::move(tags_))
     {
     }
@@ -70,7 +70,7 @@ public:
      *
      * @return The ID.
      */
-    [[nodiscard]] std::string_view id() const
+    [[nodiscard]] std::string_view id() const noexcept
     {
         return id_;
     }
@@ -79,13 +79,13 @@ public:
      *
      * @return The list of tags.
      */
-    [[nodiscard]] const std::vector<std::string>& tags() const
+    [[nodiscard]] const std::vector<std::string>& tags() const noexcept
     {
         return tags_;
     }
 
 protected:
-    ~block_base() = default;
+    ~block_base() noexcept = default;
 
     block_base(const block_base&) = default;
     block_base(block_base&&) noexcept = default;
@@ -122,11 +122,12 @@ class CARROT_EXPORT block
 public:
     /** @brief Construct a polymorphic block in its moved-from state.
      */
-    block();
+    block() noexcept;
 
 #if __cpp_concepts >= 201507
     template <Block BlockType>
-    block(BlockType self_) : self_(std::make_unique<block_wrapper<BlockType>>(std::move(self_)))
+    block(BlockType self_) noexcept
+    : self_(std::make_unique<block_wrapper<BlockType>>(std::move(self_)))
     {
     }
 #else
@@ -138,7 +139,7 @@ public:
      */
     template <typename Block,
               typename Enabler = typename std::enable_if<is_block<Block>::value>::type>
-    block(Block self_) : self_(std::make_unique<block_wrapper<Block>>(std::move(self_)))
+    block(Block self_) noexcept : self_(std::make_unique<block_wrapper<Block>>(std::move(self_)))
     {
     }
 #endif
@@ -149,7 +150,7 @@ public:
      *
      * @param other The copied block.
      */
-    block(const block& other)
+    block(const block& other) noexcept
     {
         if (other.self_)
         {
@@ -168,7 +169,7 @@ public:
      * @param other The copied block.
      * @return This object.
      */
-    block& operator=(const block& other)
+    block& operator=(const block& other) noexcept
     {
         block copy(other);
 
@@ -183,6 +184,7 @@ public:
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const
     {
@@ -200,7 +202,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const
+                                                 const style& s) const noexcept
     {
         return self_->extent(output_target, s);
     }
@@ -230,12 +232,12 @@ private:
 
         block_interface& operator=(block_interface&&) = delete;
 
-        [[nodiscard]] virtual std::unique_ptr<block_interface> clone() const = 0;
+        [[nodiscard]] virtual std::unique_ptr<const block_interface> clone() const noexcept = 0;
 
         virtual void render(form& mat, const style& s) const = 0;
 
         [[nodiscard]] virtual std::array<long int, 2> extent(const target_info& output_target,
-                                                             const style& s) const = 0;
+                                                             const style& s) const noexcept = 0;
     };
 
     template <typename Block>
@@ -246,7 +248,7 @@ private:
         {
         }
 
-        [[nodiscard]] std::unique_ptr<block_interface> clone() const override
+        [[nodiscard]] std::unique_ptr<const block_interface> clone() const noexcept final
         {
             return std::make_unique<block_wrapper<Block>>(value_);
         }
@@ -257,7 +259,7 @@ private:
         }
 
         [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                     const style& s) const override
+                                                     const style& s) const noexcept final
         {
             return value_.extent(output_target, s);
         };
@@ -266,7 +268,7 @@ private:
         Block value_;
     };
 
-    std::unique_ptr<block_interface> self_;
+    std::unique_ptr<const block_interface> self_;
 };
 
 /** @brief Concatenates two block horizontally.
@@ -275,7 +277,7 @@ private:
  * @param rhs The right-hand side block.
  * @return The concatenated blocks.
  */
-CARROT_EXPORT block operator<<(block lhs, block rhs);
+CARROT_EXPORT block operator<<(block lhs, block rhs) noexcept;
 
 class plain_form;
 
@@ -283,6 +285,7 @@ class plain_form;
  *
  * @param root The rendered block.
  * @param output_form The output form.
+ * @throws runtime_error If the block could not be rendered.
  */
 CARROT_EXPORT void render(const block& root, plain_form& output_form);
 
@@ -291,6 +294,7 @@ CARROT_EXPORT void render(const block& root, plain_form& output_form);
  * @param root The rendered block.
  * @param output_form The output form.
  * @param s The applied style.
+ * @throws runtime_error If the block could not be rendered.
  */
 CARROT_EXPORT void render(const block& root, plain_form& output_form, const style& s);
 } // namespace carrot

--- a/include/carrot/caret_block.hpp
+++ b/include/carrot/caret_block.hpp
@@ -28,7 +28,7 @@ public:
      * @param marked_block_ The block which are marked by the caret.
      * @param pos_ The position which is marked by the caret.
      */
-    explicit caret_block(block marked_block_, long int pos_);
+    explicit caret_block(block marked_block_, long int pos_) noexcept;
 
     /** @brief Construct a caret block.
      *
@@ -36,12 +36,14 @@ public:
      * @param pos_ The position which is marked by the caret.
      * @param tags_ The tags assigned to this block.
      */
-    explicit caret_block(block marked_block_, long int pos_, std::vector<std::string> tags_);
+    explicit caret_block(block marked_block_, long int pos_,
+                         std::vector<std::string> tags_) noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -56,7 +58,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     block marked_block_;
@@ -71,7 +73,7 @@ private:
  *  @return The marked block.
 */
 [[nodiscard]] CARROT_EXPORT caret_block mark_with_caret(block marked_block,
-                                                        long int caret_position);
+                                                        long int caret_position) noexcept;
 
 /** @brief Marks a block with a caret at a specific position.
  *
@@ -82,7 +84,7 @@ private:
  *  @return The marked block.
 */
 [[nodiscard]] CARROT_EXPORT caret_block mark_with_caret(block marked_block, long int caret_position,
-                                                        std::vector<std::string> tags);
+                                                        std::vector<std::string> tags) noexcept;
 } // namespace carrot
 
 #endif

--- a/include/carrot/caret_underline_block.hpp
+++ b/include/carrot/caret_underline_block.hpp
@@ -27,7 +27,7 @@ public:
      * @param underlined_element_ The block which are marked by the caret.
      * @param pos_ The position which is marked by the caret.
      */
-    caret_underline_block(block underlined_element_, long int pos_);
+    caret_underline_block(block underlined_element_, long int pos_) noexcept;
 
     /** @brief Construct a caret underline block.
      *
@@ -35,12 +35,14 @@ public:
      * @param pos_ The position which is marked by the caret.
      * @param tags_ The tags assigned to this block.
      */
-    caret_underline_block(block underlined_element_, long int pos_, std::vector<std::string> tags_);
+    caret_underline_block(block underlined_element_, long int pos_,
+                          std::vector<std::string> tags_) noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -55,7 +57,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     block underlined_element_;
@@ -69,8 +71,8 @@ private:
  *
  *  @return The marked block.
 */
-[[nodiscard]] CARROT_EXPORT caret_underline_block underline_with_caret(block underlined_block,
-                                                                       long int caret_position);
+[[nodiscard]] CARROT_EXPORT caret_underline_block
+underline_with_caret(block underlined_block, long int caret_position) noexcept;
 
 /** @brief Marks a block with a caret at a specific position and underlines it.
  *
@@ -81,7 +83,7 @@ private:
  *  @return The marked block.
 */
 [[nodiscard]] CARROT_EXPORT caret_underline_block underline_with_caret(
-    block underlined_block, long int caret_position, std::vector<std::string> tags);
+    block underlined_block, long int caret_position, std::vector<std::string> tags) noexcept;
 } // namespace carrot
 
 #endif

--- a/include/carrot/checkbox_list_block.hpp
+++ b/include/carrot/checkbox_list_block.hpp
@@ -6,8 +6,8 @@
 #ifndef CARROT_CHECKBOX_BLOCK_HPP
 #define CARROT_CHECKBOX_BLOCK_HPP
 
-#include <carrot/grid_block.hpp>
 #include <carrot/block.hpp>
+#include <carrot/grid_block.hpp>
 
 #include "carrot_export.hpp"
 
@@ -25,7 +25,7 @@ class CARROT_EXPORT checkbox_list_block final : public block_base<checkbox_list_
 public:
     /** @brief Constructs a new empty list.
      */
-    checkbox_list_block();
+    checkbox_list_block() noexcept;
 
     /** @brief Adds a new block to the list.
      *
@@ -33,12 +33,13 @@ public:
      * @param description The block which is used as the description for the new list item.
      * @return This list.
      */
-    checkbox_list_block& add(bool enabled, block description);
+    checkbox_list_block& add(bool enabled, block description) noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -52,7 +53,9 @@ public:
      * @param s The applied style.
      * @return The extent of the block.
      */
-    [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target, const style& s) const;
+    [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
+                                                 const style& s) const noexcept;
+
 private:
     grid_block grid_;
 };
@@ -61,8 +64,8 @@ private:
  *
  * @return The new list.
  */
-[[nodiscard]] CARROT_EXPORT checkbox_list_block make_checkbox_list();
+[[nodiscard]] CARROT_EXPORT checkbox_list_block make_checkbox_list() noexcept;
 
-}
+} // namespace carrot
 
 #endif

--- a/include/carrot/color.hpp
+++ b/include/carrot/color.hpp
@@ -21,11 +21,13 @@
  */
 namespace carrot
 {
-class CARROT_EXPORT invalid_color_error : public virtual exception, public virtual std::runtime_error
+/** @brief Exception thrown if an invalid color has been encountered.
+ */
+class CARROT_EXPORT invalid_color_error : public ::carrot::runtime_error
 {
 public:
     explicit invalid_color_error(std::string message_)
-    : std::runtime_error("Invalid color: " + std::move(message_))
+    : runtime_error("Invalid color: " + std::move(message_))
     {
     }
 };
@@ -55,7 +57,7 @@ public:
     /** @brief The red component.
      * @return The component.
      */
-    [[nodiscard]] constexpr short red() const
+    [[nodiscard]] constexpr short red() const noexcept
     {
         return red_;
     }
@@ -63,7 +65,7 @@ public:
     /** @brief The green component.
     * @return The component.
     */
-    [[nodiscard]] constexpr short green() const
+    [[nodiscard]] constexpr short green() const noexcept
     {
         return green_;
     }
@@ -71,10 +73,11 @@ public:
     /** @brief The blue component.
     * @return The component.
     */
-    [[nodiscard]] constexpr short blue() const
+    [[nodiscard]] constexpr short blue() const noexcept
     {
         return blue_;
     }
+
 private:
     short red_;
     short green_;
@@ -101,7 +104,7 @@ public:
      *
      * @return The component.
      */
-    [[nodiscard]] constexpr float hue() const
+    [[nodiscard]] constexpr float hue() const noexcept
     {
         return hue_;
     }
@@ -110,7 +113,7 @@ public:
      *
      * @return The component.
      */
-    [[nodiscard]] constexpr float saturation() const
+    [[nodiscard]] constexpr float saturation() const noexcept
     {
         return saturation_;
     }
@@ -119,7 +122,7 @@ public:
      *
      * @return The component.
      */
-    [[nodiscard]] constexpr float lightness() const
+    [[nodiscard]] constexpr float lightness() const noexcept
     {
         return lightness_;
     }
@@ -138,7 +141,7 @@ public:
     /** @brief Construct a new named color.
      * @param name_ The name of the color.
      */
-    explicit named_color(std::string name_) : name_(std::move(name_))
+    explicit named_color(std::string name_) noexcept : name_(std::move(name_))
     {
     }
 
@@ -146,7 +149,7 @@ public:
      *
      * @return The name.
      */
-    [[nodiscard]] const std::string& name() const
+    [[nodiscard]] const std::string& name() const noexcept
     {
         return name_;
     }
@@ -170,12 +173,13 @@ public:
      * @param c The color value.
      * @return This table.
      */
-    color_table& add_color(std::string name, color c);
+    color_table& add_color(std::string name, color c) noexcept;
 
     /** @brief Lookup a named color.
      *
      * @param name The name of the color.
      * @return The color with the specified name.
+     * @throws runtime_error If the name does not correspond with a valid color.
      */
     const color& lookup_color(const std::string& name) const;
 
@@ -187,7 +191,7 @@ private:
  *
  * @return The default color table.
  */
-[[nodiscard]] CARROT_EXPORT color_table get_default_color_table();
+[[nodiscard]] CARROT_EXPORT color_table get_default_color_table() noexcept;
 
 /** @brief Converts a color into its RGB representation.
  *
@@ -196,6 +200,7 @@ private:
  * @param c The converted color.
  * @param ctable The color tabled used to convert named colors.
  * @return The RGB representation.
+ * @throws runtime_error If the color has no valid RGB representation.
  */
 [[nodiscard]] CARROT_EXPORT rgb_color rgb(const color& c, const color_table& ctable);
 
@@ -205,6 +210,7 @@ private:
  *
  * @param c The converted color.
  * @return The RGB representation.
+ * @throws runtime_error If the color has no valid RGB representation.
  */
 [[nodiscard]] CARROT_EXPORT rgb_color rgb(const color& c);
 
@@ -213,7 +219,7 @@ private:
  * @param c The converted color.
  * @return The RGB representation.
  */
-[[nodiscard]] CARROT_EXPORT rgb_color rgb(rgb_color c);
+[[nodiscard]] CARROT_EXPORT rgb_color rgb(rgb_color c) noexcept;
 
 /** @brief Converts a color into its HSL representation.
  *
@@ -222,6 +228,7 @@ private:
  * @param c The converted color.
  * @param ctable The color tabled used to convert named colors.
  * @return The HSL representation.
+ * @throws runtime_error If the color has no valid HLS representation.
  */
 [[nodiscard]] CARROT_EXPORT hsl_color hsl(const color& c, const color_table& ctable);
 
@@ -231,6 +238,7 @@ private:
  *
  * @param c The converted color.
  * @return The HSL representation.
+ * @throws runtime_error If the color has no valid HLS representation.
  */
 [[nodiscard]] CARROT_EXPORT hsl_color hsl(const color& c);
 
@@ -239,7 +247,7 @@ private:
  * @param c The converted color.
  * @return The HSL representation.
  */
-[[nodiscard]] CARROT_EXPORT hsl_color hsl(hsl_color c);
+[[nodiscard]] CARROT_EXPORT hsl_color hsl(hsl_color c) noexcept;
 
 /** @brief Canonicalizes the specified color.
  *
@@ -247,6 +255,7 @@ private:
  * @param c The color which is canonicalized.
  * @param ctable The color table used to canonicalize named colors.
  * @return The canonicalized colors.
+ * @throws runtime_error If the color has no canonical representation.
  */
 [[nodiscard]] CARROT_EXPORT color canonicalize(const color& c, const color_table& ctable);
 
@@ -255,6 +264,7 @@ private:
  * @param color1 The first color.
  * @param color2 The second color.
  * @return The distance.
+ * @throws runtime_error If the distance could not be calculated.
  */
 [[nodiscard]] CARROT_EXPORT float distance(const color& color1, const color& color2);
 
@@ -262,20 +272,24 @@ private:
  *
  * @return The default color.
  */
-[[nodiscard]] CARROT_EXPORT color get_default_color();
+[[nodiscard]] CARROT_EXPORT color get_default_color() noexcept;
 
 /** @brief Determines if the specified color is the default color.
  *
  * @param c The tested color.
  * @return True if the tested color is the default color, false otherwise.
  */
-[[nodiscard]] CARROT_EXPORT bool is_default_color(const color& c);
+[[nodiscard]] CARROT_EXPORT bool is_default_color(const color& c) noexcept;
+
+/// The size of the XTerm color table.
+constexpr int xterm_color_table_size = 256;
 
 /** @brief Gets the XTerm color table.
  *
  * @return The XTerm color table.
  */
-[[nodiscard]] CARROT_EXPORT const std::array<hsl_color, 256>& get_xterm_color_table();
-}
+[[nodiscard]] CARROT_EXPORT const std::array<hsl_color, xterm_color_table_size>&
+get_xterm_color_table() noexcept;
+} // namespace carrot
 
 #endif

--- a/include/carrot/color_map.hpp
+++ b/include/carrot/color_map.hpp
@@ -14,33 +14,46 @@
 #include <vector>
 #include <stdexcept>
 
+/** @brief carrot's root namespace.
+ */
 namespace carrot
 {
 
-class CARROT_EXPORT invalid_color_map_error : public virtual exception, public virtual std::runtime_error
-{
-public:
-    explicit invalid_color_map_error(const std::string& message_)
-    : std::runtime_error("Invalid color map: " + message_)
-    {
-    }
-};
-
+/** @brief A color index which will map an arbitrary color to
+ *         its "best" representation in the map.
+ *
+ *         For performance reason, the map will just return the index
+ *         of the color.
+ */
 class CARROT_EXPORT color_map
 {
 public:
+    /** @brief Construct a new color map from a range of colors.
+     *
+     * @tparam Colors The type of the color range.
+     * @param available_colors_ The range of color from which the map will be initialized.
+     * @throws runtime_error If no valid color map could be constructed.
+     */
     template<typename Colors>
     explicit color_map(const Colors& available_colors_)
     {
+        // Initialized the color index.
         for (const auto& color : available_colors_)
         {
             this->available_colors_.push_back(hsl(color));
         }
 
+        // Error out if the map is invalid after construction.
         if (this->available_colors_.empty())
-            throw invalid_color_map_error("Insufficient number of colors.");
+            throw runtime_error("Invalid color map: Insufficient number of colors.");
     }
 
+    /** @brief Map the color to its "best" representation in the map.
+     *
+     * @param c The mapped color.
+     * @return The index for the "best" representation of the color.
+     * @throws runtime_error If the color could not be mapped.
+     */
     [[nodiscard]] std::size_t map_color(const color& c) const;
 private:
     std::vector<hsl_color> available_colors_;

--- a/include/carrot/empty_block.hpp
+++ b/include/carrot/empty_block.hpp
@@ -24,8 +24,9 @@ public:
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
-    void render(form & output_form, const style& s) const;
+    void render(form& output_form, const style& s) const;
 
     /** @brief Calculates the extent of the block.
      *
@@ -37,14 +38,15 @@ public:
      * @param s The applied style.
      * @return The extent of the block.
      */
-    [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target, const style& s) const;
+    [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
+                                                 const style& s) const noexcept;
 };
 
 /** @brief Creates a new empty block.
  *
  * @return The new block.
  */
-[[nodiscard]] CARROT_EXPORT block make_empty();
-}
+[[nodiscard]] CARROT_EXPORT block make_empty() noexcept;
+} // namespace carrot
 
 #endif

--- a/include/carrot/exception.hpp
+++ b/include/carrot/exception.hpp
@@ -10,17 +10,35 @@
 
 #include <exception>
 #include <stdexcept>
+#include <utility>
 
+/** @brief carrot's root namespace.
+ */
 namespace carrot
 {
 
+/** @brief The base class for all exceptions thrown by carrot.
+ */
 class CARROT_EXPORT exception : public std::exception
 {
 };
 
-class CARROT_EXPORT runtime_error : public virtual exception, public virtual std::runtime_error
+/** @brief A runtime error thrown by carrot.
+ */
+class CARROT_EXPORT runtime_error : public virtual exception
 {
-    using std::runtime_error::runtime_error;
+public:
+    explicit runtime_error(std::string message)
+    : m_message(std::move(message))
+    {
+    }
+
+    [[nodiscard]] const char* what() const noexcept override
+    {
+        return m_message.c_str();
+    }
+private:
+    std::string m_message;
 };
 
 }

--- a/include/carrot/form.hpp
+++ b/include/carrot/form.hpp
@@ -25,8 +25,8 @@ namespace carrot
 class CARROT_EXPORT form
 {
 public:
-    form() = default;
-    virtual ~form() = default;
+    form() noexcept = default;
+    virtual ~form() noexcept = default;
 
     form(const form&) = delete;
     form& operator=(const form&) = delete;
@@ -42,6 +42,7 @@ public:
      * @param row The row index of the slot.
      * @param column The column index of the slot.
      * @param value The new value of the slot.
+     * @throws runtime_error If the slot could not be set.
      */
     virtual void set(long int row, long int column, glyph value) = 0;
 
@@ -49,7 +50,7 @@ public:
      *
      * @return The backing target.
      */
-    [[nodiscard]] virtual const target_info& target() const = 0;
+    [[nodiscard]] virtual const target_info& target() const noexcept = 0;
 };
 }
 

--- a/include/carrot/form_view.hpp
+++ b/include/carrot/form_view.hpp
@@ -28,13 +28,14 @@ public:
      * @param row_offset_ The row offset.
      * @param column_offset_ The column offset.
      */
-    explicit form_view(form& base_form_, long int row_offset_, long int column_offset_);
+    explicit form_view(form& base_form_, long int row_offset_, long int column_offset_) noexcept;
 
     /** @brief Sets the specified form slot to the provided glyph.
      *
      * @param row The row index of the slot.
      * @param column The column index of the slot.
      * @param value The new value of the slot.
+     * @throws runtime_error If the slot could not be set.
      */
     void set(long int row, long int column, glyph value) final;
 
@@ -44,7 +45,7 @@ public:
      *
      * @return The backing target.
      */
-    [[nodiscard]] const target_info& target() const final;
+    [[nodiscard]] const target_info& target() const noexcept final;
 
 private:
     form* base_form_;

--- a/include/carrot/frame_block.hpp
+++ b/include/carrot/frame_block.hpp
@@ -25,12 +25,13 @@ public:
      * @param framed_block_ The framed block.
      * @param margin_ The margin between the frame and its content.
      */
-    explicit frame_block(block framed_block_, long int margin_ = 1);
+    explicit frame_block(block framed_block_, long int margin_ = 1) noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -45,7 +46,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     block framed_block_;
@@ -58,7 +59,7 @@ private:
  * @param margin The margin between the frame and its content.
  * @return
  */
-[[nodiscard]] CARROT_EXPORT frame_block frame(block framed_block, long int margin = 1);
+[[nodiscard]] CARROT_EXPORT frame_block frame(block framed_block, long int margin = 1) noexcept;
 
 } // namespace carrot
 

--- a/include/carrot/glyph.hpp
+++ b/include/carrot/glyph.hpp
@@ -25,19 +25,21 @@ struct CARROT_EXPORT glyph
     /** @brief Constructs an empty glyph.
      *
      */
-    glyph();
+    glyph() noexcept;
 
     /** @brief Constructs a glyph from the specified character.
      *
      * @param content The content of the glyph.
      */
-    glyph(char content);
+    glyph(char content) noexcept;
 
     /** @brief Constructs a glyph from the specified UTF-8 encoded grapheme cluster.
      *
+     * @pre content should contain a valid UTF-encoded grapheme cluster.
+     *
      * @param content The content of the glyph.
      */
-    explicit glyph(std::string content);
+    explicit glyph(std::string content) noexcept;
 
     /** @brief Constructs a glyph from the specified character and styling options.
      *
@@ -46,25 +48,32 @@ struct CARROT_EXPORT glyph
      * @param background_color The background color of the glyph.
      * @param bold Marks the glyph as bold.
      */
-    glyph(char content, color foreground_color, color background_color, bool bold);
+    explicit glyph(char content, color foreground_color, color background_color,
+                   bool bold) noexcept;
 
     /** @brief Constructs a glyph from the specified UTF-8 encoded grapheme cluster and styling options.
+     *
+     * @pre content should contain a valid UTF-encoded grapheme cluster.
      *
      * @param content The content of the glyph.
      * @param foreground_color The foreground color of the glyph.
      * @param background_color The background color of the glyph.
      * @param bold Marks the glyph as bold.
      */
-    glyph(std::string content, color foreground_color, color background_color, bool bold);
+    explicit glyph(std::string content, color foreground_color, color background_color,
+                   bool bold) noexcept;
 
     /** @brief Constructs a glyph from the specified UTF-8 encoded grapheme cluster and styling options.
+     *
+     * @pre content should contain a valid UTF-encoded grapheme cluster.
      *
      * @param content The content of the glyph.
      * @param foreground_color The foreground color of the glyph.
      * @param background_color The background color of the glyph.
      * @param bold Marks the glyph as bold.
      */
-    glyph(std::string_view content, color foreground_color, color background_color, bool bold);
+    explicit glyph(std::string_view content, color foreground_color, color background_color,
+                   bool bold) noexcept;
 
     /// The content of the glyph as a UTF-8 encoded grapheme cluster.
     std::string content;
@@ -75,6 +84,6 @@ struct CARROT_EXPORT glyph
     /// True, if the glyph is bold. False, otherwise.
     bool bold;
 };
-}
+} // namespace carrot
 
 #endif

--- a/include/carrot/grid_block.hpp
+++ b/include/carrot/grid_block.hpp
@@ -37,7 +37,7 @@ public:
      * @param rows_ The number of rows.
      * @param columns_ The number of columns.
      */
-    grid_block(long int rows_, long int columns_);
+    grid_block(long int rows_, long int columns_) noexcept;
 
     /** @brief Sets the grid slot to another block.
      *
@@ -45,44 +45,45 @@ public:
      * @param column The column index.
      * @param b The assigned block.
      */
-    void set(long int row, long int column, block b);
+    void set(long int row, long int column, block b) noexcept;
 
     /** @brief Appends a number of new rows.
      *
      * @param n The number of new rows.
      */
-    void append_rows(long int n);
+    void append_rows(long int n) noexcept;
 
     /** @brief Appends a number of new columns.
      *
      * @param n The number of new columns.
      */
-    void append_columns(long int n);
+    void append_columns(long int n) noexcept;
 
     /** @brief Appends a single row.
      */
-    void append_row();
+    void append_row() noexcept;
 
     /** @brief Appends a single column.
      */
-    void append_column();
+    void append_column() noexcept;
 
     /** @brief The number of rows.
      *
      * @return The number of rows.
      */
-    [[nodiscard]] long int rows() const;
+    [[nodiscard]] long int rows() const noexcept;
 
     /** @brief The number of columns.
      *
      * @return The number of columns.
      */
-    [[nodiscard]] long int cols() const;
+    [[nodiscard]] long int cols() const noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -97,11 +98,11 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     [[nodiscard]] std::tuple<std::vector<long int>, std::vector<long int>>
-    compute_layout(const target_info& output_target, const style& s) const;
+    compute_layout(const target_info& output_target, const style& s) const noexcept;
 
     boost::multi_array<block, 2> blocks_;
 };
@@ -112,7 +113,7 @@ private:
  * @param columns The number of columns.
  * @return The new grid.
  */
-[[nodiscard]] CARROT_EXPORT grid_block make_grid(long int rows, long int columns);
+[[nodiscard]] CARROT_EXPORT grid_block make_grid(long int rows, long int columns) noexcept;
 } // namespace carrot
 
 #endif

--- a/include/carrot/indent_block.hpp
+++ b/include/carrot/indent_block.hpp
@@ -10,31 +10,85 @@
 
 #include "carrot_export.hpp"
 
+/** @brief carrot's root namespace.
+ */
 namespace carrot
 {
 
+/** @brief An indented block.
+ */
 class CARROT_EXPORT indent_block final : public block_base<indent_block>
 {
 public:
-    indent_block(block indented_block_, long int indent_levels_);
-    indent_block(block indented_block_, long int indent_levels_, std::vector<std::string> tags_);
+    /** @brief Constructs a new indented block.
+     *
+     * @param indented_block_ The block which will be indented.
+     * @param indent_levels_ The number of level by which the block will be indented.
+     */
+    explicit indent_block(block indented_block_, long int indent_levels_) noexcept;
 
+    /** @brief Constructs a new indented block.
+     *
+     * @param indented_block_ The block which will be indented.
+     * @param indent_levels_ The number of level by which the block will be indented.
+     * @param tags_ The tags assigned to this block.
+     */
+    explicit indent_block(block indented_block_, long int indent_levels_,
+                          std::vector<std::string> tags_) noexcept;
+
+    /** @brief Renders the block into the provided form using the specified style.
+     *
+     * @param output_form The output form.
+     * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
+     */
     void render(form& output_form, const style& s) const;
 
+    /** @brief Calculates the extent of the block.
+     *
+     * To calculate the extent, it is assumed that the block
+     * will be rendered using the specified style and will
+     * be displayed by the provided target.
+     *
+     * @param output_target The output target.
+     * @param s The applied style.
+     * @return The extent of the block.
+     */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     block indented_block_;
     long int indent_levels_;
 };
 
-[[nodiscard]] CARROT_EXPORT indent_block indent(block indented_block, long int indent_levels = 1);
-
+/** @brief Indents a block.
+ *
+ * @param indented_block The block which will be indented.
+ * @param indent_levels The number of level by which the block will be indented.
+ * @return The indented block.
+ */
 [[nodiscard]] CARROT_EXPORT indent_block indent(block indented_block,
-                                                std::vector<std::string> tags);
+                                                long int indent_levels = 1) noexcept;
+
+/** @brief Indents a block by one level.
+ *
+ * @param indented_block The block which will be indented.
+ * @param tags The tags assigned to this block.
+ * @return The indented block.
+ */
+[[nodiscard]] CARROT_EXPORT indent_block indent(block indented_block,
+                                                std::vector<std::string> tags) noexcept;
+
+/** @brief Indents a block.
+ *
+ * @param indented_block The block which will be indented.
+ * @param indent_levels The number of level by which the block will be indented.
+ * @param tags The tags assigned to this block.
+ * @return The indented block.
+ */
 [[nodiscard]] CARROT_EXPORT indent_block indent(block indented_block, long int indent_levels,
-                                                std::vector<std::string> tags);
+                                                std::vector<std::string> tags) noexcept;
 
 } // namespace carrot
 

--- a/include/carrot/integers.hpp
+++ b/include/carrot/integers.hpp
@@ -14,7 +14,7 @@ namespace carrot
  * @return The converted value.
  */
 template <typename Destination, typename Source>
-[[nodiscard]] constexpr Destination integer_cast(const Source& value)
+[[nodiscard]] constexpr Destination integer_cast(const Source& value) noexcept
 {
     return static_cast<Destination>(value);
 }

--- a/include/carrot/irregular_grid_block.hpp
+++ b/include/carrot/irregular_grid_block.hpp
@@ -47,13 +47,13 @@ public:
          * @param s The applied style.
          * @return The extent of the row.
          */
-        std::array<long int, 2> extent(const target_info& output_target, const style& s) const;
+        std::array<long int, 2> extent(const target_info& output_target, const style& s) const noexcept;
 
         /** @brief Appends another block to the row.
          *
          * @param element The block to be added.
          */
-        void append(block element);
+        void append(block element) noexcept;
 
     private:
         std::vector<block> elements_;
@@ -64,12 +64,13 @@ public:
      * @param row The index of the row.
      * @param element The block to be added.
      */
-    void add_to_row(long int row, block element);
+    void add_to_row(long int row, block element) noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -84,7 +85,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     std::vector<row> rows_;
@@ -96,7 +97,7 @@ private:
  *
  * @return The new grid.
  */
-[[nodiscard]] CARROT_EXPORT irregular_grid_block make_irregular_grid();
+[[nodiscard]] CARROT_EXPORT irregular_grid_block make_irregular_grid() noexcept;
 } // namespace carrot
 
 #endif

--- a/include/carrot/line_block.hpp
+++ b/include/carrot/line_block.hpp
@@ -35,7 +35,7 @@ public:
      *
      * @param direction_ The direction in which the line grows.
      */
-    explicit line_block(growth_direction direction_);
+    explicit line_block(growth_direction direction_) noexcept;
 
     /** @brief Adds another block to the line.
      *
@@ -45,12 +45,13 @@ public:
      * @param b The block to be added.
      * @return This line.
      */
-    line_block& add(block b);
+    line_block& add(block b) noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -65,7 +66,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     growth_direction direction_;
@@ -77,7 +78,7 @@ private:
  * @param direction The growth direction of the line.
  * @return The new line.
  */
-[[nodiscard]] CARROT_EXPORT line_block make_line(growth_direction direction);
+[[nodiscard]] CARROT_EXPORT line_block make_line(growth_direction direction) noexcept;
 
 /** @brief Connects a list of blocks as a horizontal line.
  *
@@ -86,7 +87,7 @@ private:
  * @return The new line.
  */
 template <typename... Blocks>
-[[nodiscard]] CARROT_EXPORT line_block connect(Blocks... blocks)
+[[nodiscard]] CARROT_EXPORT line_block connect(Blocks... blocks) noexcept
 {
     auto line = line_block(growth_direction::right);
 

--- a/include/carrot/list_block.hpp
+++ b/include/carrot/list_block.hpp
@@ -23,19 +23,20 @@ class CARROT_EXPORT list_block final : public block_base<list_block>
 public:
     /** @brief Constructs an empty list.
      */
-    list_block();
+    list_block() noexcept;
 
     /** @brief Adds a new block to the end of the list.
      *
      * @param b The block to be added.
      * @return This list.
      */
-    list_block& add(block b);
+    list_block& add(block b) noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -50,7 +51,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     grid_block grid_;
@@ -60,7 +61,7 @@ private:
  *
  * @return The new list.
  */
-[[nodiscard]] CARROT_EXPORT list_block make_list();
+[[nodiscard]] CARROT_EXPORT list_block make_list() noexcept;
 
 } // namespace carrot
 

--- a/include/carrot/placeholder_block.hpp
+++ b/include/carrot/placeholder_block.hpp
@@ -27,12 +27,13 @@ public:
      *
      * @param tags_ The tags associated with the placeholder.
      */
-    explicit placeholder_block(std::vector<std::string> tags_);
+    explicit placeholder_block(std::vector<std::string> tags_) noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -47,7 +48,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 };
 
 /** @brief Creates a new placeholder.
@@ -55,7 +56,7 @@ public:
  * @param tags The tags associated with the placeholder.
  * @return The placeholder.
  */
-[[nodiscard]] CARROT_EXPORT placeholder_block placeholder(std::vector<std::string> tags);
+[[nodiscard]] CARROT_EXPORT placeholder_block placeholder(std::vector<std::string> tags) noexcept;
 
 } // namespace carrot
 

--- a/include/carrot/plain_form.hpp
+++ b/include/carrot/plain_form.hpp
@@ -30,7 +30,7 @@ public:
      * @param rows_ The initial number of rows.
      * @param columns_ The initial number of columns.
      */
-    plain_form(target_info target_, long int rows_ = 0, long int columns_ = 0);
+    plain_form(target_info target_, long int rows_ = 0, long int columns_ = 0) noexcept;
 
     /** @brief Sets the specified form slot to the provided glyph.
      *
@@ -40,6 +40,7 @@ public:
      * @param row The row index of the slot.
      * @param column The column index of the slot.
      * @param value The new value of the slot.
+     * @throws runtime_error If the slot could not be set.
      */
     void set(long int row, long int column, glyph value) final;
 
@@ -47,17 +48,18 @@ public:
      *
      * @return The backing target.
      */
-    [[nodiscard]] const target_info& target() const final;
+    [[nodiscard]] const target_info& target() const noexcept final;
 
     /** @brief Converts the content of the form to a UTF-8 encoded string.
      *
      * @return The contents as a UTF-8 encoded string.
+     * @throws runtime_error If the content of the form could not be converted.
      */
     [[nodiscard]] std::string to_string() const;
 
     /** @brief Clear the form.
      */
-    void clear();
+    void clear() noexcept;
 
     /** @brief Clear the form.
      *
@@ -65,10 +67,10 @@ public:
      *
      * @param value The glyph used to clear each slot.
      */
-    void clear(glyph value);
+    void clear(glyph value) noexcept;
 
 private:
-    void resize_if_outside_matrix(long int row, long int column);
+    void resize_if_outside_matrix(long int row, long int column) noexcept;
 
     target_info target_;
     boost::multi_array<glyph, 2> data_;

--- a/include/carrot/progress_bar_block.hpp
+++ b/include/carrot/progress_bar_block.hpp
@@ -25,12 +25,13 @@ public:
      *
      * @param progress_ The progress.
      */
-    explicit progress_bar_block(long int progress_);
+    explicit progress_bar_block(long int progress_) noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -45,7 +46,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     text_block text_;
@@ -56,7 +57,7 @@ private:
  * @param progress The progress.
  * @return The progress bar.
  */
-[[nodiscard]] CARROT_EXPORT progress_bar_block progress_bar(long int progress);
+[[nodiscard]] CARROT_EXPORT progress_bar_block progress_bar(long int progress) noexcept;
 } // namespace carrot
 
 #endif

--- a/include/carrot/table_block.hpp
+++ b/include/carrot/table_block.hpp
@@ -20,13 +20,6 @@
 namespace carrot
 {
 
-class CARROT_EXPORT invalid_number_of_columns_error : public virtual exception,
-                                                      public virtual std::logic_error
-{
-public:
-    invalid_number_of_columns_error(long int expected, long int provided);
-};
-
 /** @brief A block representing a table of blocks.
  */
 class CARROT_EXPORT table_block final : public block_base<table_block>
@@ -38,7 +31,7 @@ public:
      *
      * @param columns_ The number of columns.
      */
-    explicit table_block(long int columns_);
+    explicit table_block(long int columns_) noexcept;
 
     /** @brief Adds another row to the table.
      *
@@ -47,6 +40,8 @@ public:
      *
      * @param columns The columns which form the row.
      * @return This table.
+     * @throws runtime_error If the number of provided columns does not the match
+     *                       the number of columns in the table.
      */
     table_block& add_row(std::vector<block> columns);
 
@@ -54,6 +49,7 @@ public:
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -68,7 +64,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     grid_block grid_;
@@ -80,7 +76,7 @@ private:
  * @param columns The number of columns in the table.
  * @return The new table.
  */
-[[nodiscard]] CARROT_EXPORT table_block make_table(long int columns);
+[[nodiscard]] CARROT_EXPORT table_block make_table(long int columns) noexcept;
 } // namespace carrot
 
 #endif

--- a/include/carrot/target_info.hpp
+++ b/include/carrot/target_info.hpp
@@ -11,14 +11,13 @@
 #include "carrot_export.hpp"
 
 #include <locale>
-#include <stdexcept>
 
 /** @brief carrot's root namespace.
  */
 namespace carrot
 {
 
-class CARROT_EXPORT invalid_target_error : public virtual exception, public virtual std::logic_error
+class CARROT_EXPORT invalid_target_error : public runtime_error
 {
 public:
     explicit invalid_target_error(const std::string& reason_);
@@ -36,25 +35,25 @@ public:
      * @param tab_width_ The tabulator width.
      */
     explicit target_info(const std::locale& locale_, bool supports_colorized_output_,
-                         long int tab_width_);
+                         long int tab_width_) noexcept;
 
     /** @brief Query if colorized output is supported.
      *
      * @return True, if colorized output is supported.
      */
-    [[nodiscard]] bool supports_colorized_output() const;
+    [[nodiscard]] bool supports_colorized_output() const noexcept;
 
     /** @brief Queries the tabulator width.
      *
      * @return The tabulator width.
      */
-    [[nodiscard]] long int tab_width() const;
+    [[nodiscard]] long int tab_width() const noexcept;
 
     /** @brief Queries the locale of the target.
      *
      * @return The locale.
      */
-    [[nodiscard]] const std::locale& locale() const;
+    [[nodiscard]] const std::locale& locale() const noexcept;
 
 private:
     std::locale locale_;
@@ -67,7 +66,7 @@ private:
  * @param tab_width The tabulator width.
  * @return The target information.
  */
-[[nodiscard]] CARROT_EXPORT target_info get_stdout_target(long int tab_width = 4);
+[[nodiscard]] CARROT_EXPORT target_info get_stdout_target(long int tab_width = 4) noexcept;
 
 /** @brief Queries the target information for the standard output.
  *
@@ -76,14 +75,14 @@ private:
  * @return The target information.
  */
 [[nodiscard]] CARROT_EXPORT target_info get_stdout_target(const std::locale& locale,
-                                                          long int tab_width = 4);
+                                                          long int tab_width = 4) noexcept;
 
 /** @brief Queries the target information for an arbitrary text file target.
  *
  * @param tab_width The tabulator width.
  * @return The target information.
  */
-[[nodiscard]] CARROT_EXPORT target_info get_file_target(long int tab_width = 4);
+[[nodiscard]] CARROT_EXPORT target_info get_file_target(long int tab_width = 4) noexcept;
 
 /** @brief Queries the target information for an arbitrary text file target.
  *
@@ -92,14 +91,14 @@ private:
  * @return The target information.
  */
 [[nodiscard]] CARROT_EXPORT target_info get_file_target(const std::locale& locale,
-                                                        long int tab_width = 4);
+                                                        long int tab_width = 4) noexcept;
 
 /** @brief Queries the target information for a generic target with colorization support.
  *
  * @param tab_width The tabulator width.
  * @return The target information.
  */
-[[nodiscard]] CARROT_EXPORT target_info get_colorized_target(long int tab_width = 4);
+[[nodiscard]] CARROT_EXPORT target_info get_colorized_target(long int tab_width = 4) noexcept;
 
 /** @brief Queries the target information for a generic target with colorization support.
  *
@@ -108,7 +107,7 @@ private:
  * @return The target information.
  */
 [[nodiscard]] CARROT_EXPORT target_info get_colorized_target(const std::locale& locale,
-                                                             long int tab_width = 4);
+                                                             long int tab_width = 4) noexcept;
 
 } // namespace carrot
 

--- a/include/carrot/text_block.hpp
+++ b/include/carrot/text_block.hpp
@@ -30,19 +30,20 @@ public:
      *
      * @param content_ The content.
      */
-    explicit text_block(std::string_view content_);
+    explicit text_block(std::string_view content_) noexcept;
 
     /** @brief Constructs a text block.
      *
      * @param content_ The content.
      * @param tags_ The tags associated with this block.
      */
-    text_block(std::string_view content_, std::vector<std::string> tags_);
+    text_block(std::string_view content_, std::vector<std::string> tags_) noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -57,7 +58,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     std::vector<std::string> rows_;
@@ -68,7 +69,7 @@ private:
  * @param content The content.
  * @return The new text block.
  */
-[[nodiscard]] CARROT_EXPORT text_block text(std::string_view content);
+[[nodiscard]] CARROT_EXPORT text_block text(std::string_view content) noexcept;
 
 /** @brief Creates a new text block.
  *
@@ -77,7 +78,7 @@ private:
  * @return The new text block.
  */
 [[nodiscard]] CARROT_EXPORT text_block text(std::string_view content,
-                                            std::vector<std::string> tags);
+                                            std::vector<std::string> tags) noexcept;
 
 } // namespace carrot
 

--- a/include/carrot/underline_block.hpp
+++ b/include/carrot/underline_block.hpp
@@ -24,19 +24,20 @@ public:
      *
      * @param underlined_element_ The block to be underlined.
      */
-    explicit underline_block(block underlined_element_);
+    explicit underline_block(block underlined_element_) noexcept;
 
     /** @brief Constructs a new underlined block.
      *
      * @param underlined_element_ The block to be underlined.
      * @param tags_ The tags associated with this block.
      */
-    underline_block(block underlined_element_, std::vector<std::string> tags_);
+    underline_block(block underlined_element_, std::vector<std::string> tags_) noexcept;
 
     /** @brief Renders the block into the provided form using the specified style.
      *
      * @param output_form The output form.
      * @param s The applied style.
+     * @throws runtime_error If the block could not be rendered.
      */
     void render(form& output_form, const style& s) const;
 
@@ -51,7 +52,7 @@ public:
      * @return The extent of the block.
      */
     [[nodiscard]] std::array<long int, 2> extent(const target_info& output_target,
-                                                 const style& s) const;
+                                                 const style& s) const noexcept;
 
 private:
     block underlined_element_;
@@ -62,7 +63,7 @@ private:
  * @param underlined_element The block to be underlined.
  * @return The underlined block.
  */
-[[nodiscard]] CARROT_EXPORT underline_block underline(block underlined_element);
+[[nodiscard]] CARROT_EXPORT underline_block underline(block underlined_element) noexcept;
 
 /** @brief Underlines a block.
  *
@@ -71,7 +72,7 @@ private:
  * @return The underlined block.
  */
 [[nodiscard]] CARROT_EXPORT underline_block underline(block underlined_element,
-                                                      std::vector<std::string> tags);
+                                                      std::vector<std::string> tags) noexcept;
 } // namespace carrot
 
 #endif

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -15,12 +15,12 @@
 namespace carrot
 {
 
-block::block()
+block::block() noexcept
 : block(make_empty())
 {
 }
 
-block operator<<(block lhs, block rhs)
+block operator<<(block lhs, block rhs) noexcept
 {
     line_block line(growth_direction::right);
 

--- a/src/caret_block.cpp
+++ b/src/caret_block.cpp
@@ -12,12 +12,13 @@
 namespace carrot
 {
 
-caret_block::caret_block(block marked_block_, long int pos_)
+caret_block::caret_block(block marked_block_, long int pos_) noexcept
 : caret_block(std::move(marked_block_), pos_, {})
 {
 }
 
-caret_block::caret_block(block marked_block_, long int pos_, std::vector<std::string> tags_)
+caret_block::caret_block(block marked_block_, long int pos_,
+                         std::vector<std::string> tags_) noexcept
 : block_base<caret_block>(std::move(tags_)), marked_block_(std::move(marked_block_)), pos_(pos_)
 {
 }
@@ -37,19 +38,21 @@ void caret_block::render(form& output_form, const style& s) const
 }
 
 std::array<long int, 2> caret_block::extent(const target_info& output_target, const style& s) const
+    noexcept
 {
     auto extent = marked_block_.extent(output_target, s);
 
     return std::array<long int, 2>{extent[0] + 1, extent[1]};
 }
 
-caret_block mark_with_caret(block marked_block, long int caret_position)
+caret_block mark_with_caret(block marked_block, long int caret_position) noexcept
 {
     return caret_block(std::move(marked_block), caret_position);
 }
 
-caret_block mark_with_caret(block marked_block, long int caret_position, std::vector<std::string> tags)
+caret_block mark_with_caret(block marked_block, long int caret_position,
+                            std::vector<std::string> tags) noexcept
 {
     return caret_block(std::move(marked_block), caret_position, std::move(tags));
 }
-}
+} // namespace carrot

--- a/src/caret_underline_block.cpp
+++ b/src/caret_underline_block.cpp
@@ -12,13 +12,13 @@
 namespace carrot
 {
 
-caret_underline_block::caret_underline_block(block underlined_element_, long int pos_)
+caret_underline_block::caret_underline_block(block underlined_element_, long int pos_) noexcept
 : caret_underline_block(std::move(underlined_element_), pos_, {})
 {
 }
 
 caret_underline_block::caret_underline_block(block underlined_element_, long int pos_,
-                                             std::vector<std::string> tags_)
+                                             std::vector<std::string> tags_) noexcept
 : block_base<caret_underline_block>(std::move(tags_)),
   underlined_element_(std::move(underlined_element_)),
   pos_(pos_)
@@ -53,21 +53,22 @@ void caret_underline_block::render(form& output_form, const style& s) const
     }
 }
 
-std::array<long int, 2> caret_underline_block::extent(const target_info& output_target, const style& s) const
+std::array<long int, 2> caret_underline_block::extent(const target_info& output_target,
+                                                      const style& s) const noexcept
 {
     auto extent = underlined_element_.extent(output_target, s);
 
     return std::array<long int, 2>{extent[0] + 1, extent[1]};
 }
 
-caret_underline_block underline_with_caret(block underlined_block, long int caret_position)
+caret_underline_block underline_with_caret(block underlined_block, long int caret_position) noexcept
 {
     return caret_underline_block(std::move(underlined_block), caret_position);
 }
 
 caret_underline_block underline_with_caret(block underlined_block, long int caret_position,
-                                           std::vector<std::string> tags)
+                                           std::vector<std::string> tags) noexcept
 {
     return caret_underline_block(std::move(underlined_block), caret_position, std::move(tags));
 }
-}
+} // namespace carrot

--- a/src/checkbox_list_block.cpp
+++ b/src/checkbox_list_block.cpp
@@ -6,19 +6,21 @@
 #include <carrot/checkbox_list_block.hpp>
 
 #include <carrot/line_block.hpp>
-#include <carrot/text_block.hpp>
 #include <carrot/placeholder_block.hpp>
 #include <carrot/style.hpp>
+#include <carrot/text_block.hpp>
 
-#include <utility>
 #include <memory>
+#include <utility>
+#include <exception>
 
 namespace carrot
 {
 
 namespace
 {
-std::unique_ptr<style> augment_style(const style& s, std::string_view id, const std::vector<std::string>& tags)
+std::unique_ptr<style> augment_style(const style& s, std::string_view id,
+                                     const std::vector<std::string>& tags)
 {
     auto symbol_color = s.get_attribute<color>("checkbox-list", id, tags, "symbol-color");
     auto symbol = s.get_attribute<std::string>("checkbox-list", id, tags, "symbol");
@@ -26,25 +28,25 @@ std::unique_ptr<style> augment_style(const style& s, std::string_view id, const 
     auto ts = std::make_unique<augmented_style>(s);
 
     ts->add_rule("*", "carrot-checkbox-list-symbol")
-            .add_attribute("color", std::move(symbol_color))
-            .add_attribute("content", std::move(symbol));
+        .add_attribute("color", std::move(symbol_color))
+        .add_attribute("content", std::move(symbol));
 
     return ts;
 }
-}
+} // namespace
 
-checkbox_list_block::checkbox_list_block()
-: grid_(0, 2)
+checkbox_list_block::checkbox_list_block() noexcept : grid_(0, 2)
 {
 }
 
-checkbox_list_block& checkbox_list_block::add(bool enabled, block description)
+checkbox_list_block& checkbox_list_block::add(bool enabled, block description) noexcept
 {
     grid_.append_row();
 
     if (enabled)
     {
-        grid_.set(grid_.rows() - 1, 0, text("[") << placeholder({"carrot-checkbox-list-symbol"}) << text("] "));
+        grid_.set(grid_.rows() - 1, 0,
+                  text("[") << placeholder({"carrot-checkbox-list-symbol"}) << text("] "));
     }
     else
     {
@@ -63,16 +65,24 @@ void checkbox_list_block::render(form& output_form, const style& s) const
     grid_.render(output_form, *ts);
 }
 
-std::array<long int, 2> checkbox_list_block::extent(const target_info& output_target, const style& s) const
+std::array<long int, 2> checkbox_list_block::extent(const target_info& output_target,
+                                                    const style& s) const noexcept
 {
-    auto ts = augment_style(s, id(), tags());
+    try
+    {
+        auto ts = augment_style(s, id(), tags());
 
-    return grid_.extent(output_target, *ts);
+        return grid_.extent(output_target, *ts);
+    }
+    catch (const std::exception&)
+    {
+        std::terminate();
+    }
 }
 
-checkbox_list_block make_checkbox_list()
+checkbox_list_block make_checkbox_list() noexcept
 {
     return checkbox_list_block();
 }
 
-}
+} // namespace carrot

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -12,7 +12,7 @@
 namespace carrot
 {
 
-color_table& color_table::add_color(std::string name, color c)
+color_table& color_table::add_color(std::string name, color c) noexcept
 {
     color_map_.emplace(std::move(name), std::move(c));
 
@@ -29,14 +29,19 @@ const color& color_table::lookup_color(const std::string& name) const
     return search_result->second;
 }
 
-color_table get_default_color_table()
+color_table get_default_color_table() noexcept
 {
     return color_table();
 }
 
 namespace
 {
-hsl_color rgb2hls(const rgb_color& c)
+/** @brief Converts an RGB-encoded color value to its HLS-encoding.
+ *
+ * @param c An RGB-encoded color value.
+ * @return The color's HLS representation.
+ */
+hsl_color rgb2hls(const rgb_color& c) noexcept
 {
     float r = c.red() / 255.0f;
     float g = c.green() / 255.0f;
@@ -80,7 +85,12 @@ hsl_color rgb2hls(const rgb_color& c)
     return hsl_color(H, S, L);
 }
 
-rgb_color hsl2rgb(const hsl_color& c)
+/** @brief Converts an HLS-encoded color value to its RGB-encoding.
+ *
+ * @param c An HLS-encoded color value.
+ * @return The color's RGB representation.
+ */
+rgb_color hsl2rgb(const hsl_color& c) noexcept
 {
     auto C = (1 - std::abs(2 * c.lightness() - 1)) * c.saturation();
 
@@ -124,7 +134,7 @@ rgb_color rgb(const color& c, const color_table& ctable)
 {
     struct rgb_converter
     {
-        explicit rgb_converter(const color_table& ctable) : ctable(&ctable)
+        explicit rgb_converter(const color_table& ctable) noexcept : ctable(&ctable)
         {
         }
 
@@ -133,12 +143,12 @@ rgb_color rgb(const color& c, const color_table& ctable)
             throw invalid_color_error("Trying to use the default color as an explicit color.");
         }
 
-        rgb_color operator()(const rgb_color& c) const
+        rgb_color operator()(const rgb_color& c) const noexcept
         {
             return c;
         }
 
-        rgb_color operator()(const hsl_color& c) const
+        rgb_color operator()(const hsl_color& c) const noexcept
         {
             return hsl2rgb(c);
         }
@@ -163,12 +173,12 @@ rgb_color rgb(const color& c)
             throw invalid_color_error("Trying to use the default color as an explicit color.");
         }
 
-        rgb_color operator()(const rgb_color& c) const
+        rgb_color operator()(const rgb_color& c) const noexcept
         {
             return c;
         }
 
-        rgb_color operator()(const hsl_color& c) const
+        rgb_color operator()(const hsl_color& c) const noexcept
         {
             return hsl2rgb(c);
         }
@@ -182,7 +192,7 @@ rgb_color rgb(const color& c)
     return boost::apply_visitor(rgb_converter(), c);
 }
 
-rgb_color rgb(rgb_color c)
+rgb_color rgb(rgb_color c) noexcept
 {
     return c;
 }
@@ -200,12 +210,12 @@ hsl_color hsl(const color& c, const color_table& ctable)
             throw invalid_color_error("Trying to use the default color as an explicit color.");
         }
 
-        hsl_color operator()(const rgb_color& c) const
+        hsl_color operator()(const rgb_color& c) const noexcept
         {
             return rgb2hls(c);
         }
 
-        hsl_color operator()(const hsl_color& c) const
+        hsl_color operator()(const hsl_color& c) const noexcept
         {
             return c;
         }
@@ -230,12 +240,12 @@ hsl_color hsl(const color& c)
             throw invalid_color_error("Trying to use the default color as an explicit color.");
         }
 
-        hsl_color operator()(const rgb_color& c) const
+        hsl_color operator()(const rgb_color& c) const noexcept
         {
             return rgb2hls(c);
         }
 
-        hsl_color operator()(const hsl_color& c) const
+        hsl_color operator()(const hsl_color& c) const noexcept
         {
             return c;
         }
@@ -249,7 +259,7 @@ hsl_color hsl(const color& c)
     return boost::apply_visitor(hsl_converter(), c);
 }
 
-hsl_color hsl(hsl_color c)
+hsl_color hsl(hsl_color c) noexcept
 {
     return c;
 }
@@ -300,19 +310,19 @@ float distance(const color& color1, const color& color2)
            std::abs(color1_hsl.lightness() - color2_hsl.lightness());
 }
 
-color get_default_color()
+color get_default_color() noexcept
 {
     return default_color();
 }
 
-bool is_default_color(const color& c)
+bool is_default_color(const color& c) noexcept
 {
     return boost::get<default_color>(&c) != nullptr;
 }
 
 namespace
 {
-constexpr std::array<hsl_color, 256> xterm_color_table = {{
+constexpr std::array<hsl_color, xterm_color_table_size> xterm_color_table = {{
     {0.00000000f, 0.0f, 0.0f},     {0.00000000f, 1.0f, 0.25f},    {120.00000000f, 1.0f, 0.25f},
     {60.00000000f, 1.0f, 0.25f},   {240.00000000f, 1.0f, 0.25f},  {300.00000000f, 1.0f, 0.25f},
     {180.00000000f, 1.0f, 0.25f},  {0.00000000f, 0.0f, 0.75f},    {0.00000000f, 0.0f, 0.5f},
@@ -402,7 +412,7 @@ constexpr std::array<hsl_color, 256> xterm_color_table = {{
 }};
 }
 
-const std::array<hsl_color, 256>& get_xterm_color_table()
+const std::array<hsl_color, xterm_color_table_size>& get_xterm_color_table() noexcept
 {
     return xterm_color_table;
 }

--- a/src/empty_block.cpp
+++ b/src/empty_block.cpp
@@ -13,12 +13,12 @@ void empty_block::render(form& output_form [[maybe_unused]], const style& s [[ma
 }
 
 std::array<long int, 2> empty_block::extent(const target_info& output_target [[maybe_unused]],
-                                            const style& s [[maybe_unused]]) const
+                                            const style& s [[maybe_unused]]) const noexcept
 {
     return std::array<long int, 2>{0, 0};
 }
 
-block make_empty()
+block make_empty() noexcept
 {
     return empty_block();
 }

--- a/src/form_view.cpp
+++ b/src/form_view.cpp
@@ -8,7 +8,7 @@
 namespace carrot
 {
 
-form_view::form_view(form & base_form_, long int row_offset_, long int column_offset_)
+form_view::form_view(form & base_form_, long int row_offset_, long int column_offset_) noexcept
 : base_form_(&base_form_), row_offset_(row_offset_), column_offset_(column_offset_)
 {
 }
@@ -18,7 +18,7 @@ void form_view::set(long int row, long int column, glyph value)
     base_form_->set(row_offset_ + row, column_offset_ + column, value);
 }
 
-const target_info& form_view::target() const
+const target_info& form_view::target() const noexcept
 {
     return base_form_->target();
 }

--- a/src/frame_block.cpp
+++ b/src/frame_block.cpp
@@ -12,12 +12,12 @@
 namespace carrot
 {
 
-frame_block::frame_block(block framed_block_, long int margin_)
+frame_block::frame_block(block framed_block_, long int margin_) noexcept
 : framed_block_(std::move(framed_block_)), margin_(margin_)
 {
 }
 
-void frame_block::render(form & output_form, const style& s) const
+void frame_block::render(form& output_form, const style& s) const
 {
     auto extent = framed_block_.extent(output_form.target(), s);
 
@@ -39,15 +39,16 @@ void frame_block::render(form & output_form, const style& s) const
 }
 
 std::array<long int, 2> frame_block::extent(const target_info& output_target, const style& s) const
+    noexcept
 {
     auto extent = framed_block_.extent(output_target, s);
 
     return std::array<long int, 2>{extent[0] + 2 * margin_ + 2, extent[1] + 2 * margin_ + 2};
 }
 
-frame_block frame(block framed_block, long int margin)
+frame_block frame(block framed_block, long int margin) noexcept
 {
     return frame_block(std::move(framed_block), margin);
 }
 
-}
+} // namespace carrot

--- a/src/glyph.cpp
+++ b/src/glyph.cpp
@@ -9,7 +9,7 @@
 
 namespace carrot
 {
-glyph::glyph()
+glyph::glyph() noexcept
 : content{' '},
   foreground_color(get_default_color()),
   background_color(get_default_color()),
@@ -17,7 +17,7 @@ glyph::glyph()
 {
 }
 
-glyph::glyph(char content)
+glyph::glyph(char content) noexcept
 : content{content},
   foreground_color(get_default_color()),
   background_color(get_default_color()),
@@ -25,7 +25,7 @@ glyph::glyph(char content)
 {
 }
 
-glyph::glyph(std::string content)
+glyph::glyph(std::string content) noexcept
 : content(std::move(content)),
   foreground_color(get_default_color()),
   background_color(get_default_color()),
@@ -33,7 +33,7 @@ glyph::glyph(std::string content)
 {
 }
 
-glyph::glyph(char content, color foreground_color, color background_color, bool bold)
+glyph::glyph(char content, color foreground_color, color background_color, bool bold) noexcept
 : content{content},
   foreground_color(std::move(foreground_color)),
   background_color(std::move(background_color)),
@@ -41,7 +41,8 @@ glyph::glyph(char content, color foreground_color, color background_color, bool 
 {
 }
 
-glyph::glyph(std::string content, color foreground_color, color background_color, bool bold)
+glyph::glyph(std::string content, color foreground_color, color background_color,
+             bool bold) noexcept
 : content(std::move(content)),
   foreground_color(std::move(foreground_color)),
   background_color(std::move(background_color)),
@@ -49,7 +50,8 @@ glyph::glyph(std::string content, color foreground_color, color background_color
 {
 }
 
-glyph::glyph(std::string_view content, color foreground_color, color background_color, bool bold)
+glyph::glyph(std::string_view content, color foreground_color, color background_color,
+             bool bold) noexcept
 : content(content),
   foreground_color(std::move(foreground_color)),
   background_color(std::move(background_color)),

--- a/src/grid_block.cpp
+++ b/src/grid_block.cpp
@@ -15,41 +15,42 @@
 namespace carrot
 {
 
-grid_block::grid_block(long int rows_, long int columns_) : blocks_(boost::extents[rows_][columns_])
+grid_block::grid_block(long int rows_, long int columns_) noexcept
+: blocks_(boost::extents[rows_][columns_])
 {
 }
 
-void grid_block::set(long int row, long int column, block b)
+void grid_block::set(long int row, long int column, block b) noexcept
 {
     blocks_[row][column] = std::move(b);
 }
 
-void grid_block::append_rows(long int n)
+void grid_block::append_rows(long int n) noexcept
 {
     blocks_.resize(boost::extents[blocks_.shape()[0] + n][blocks_.shape()[1]]);
 }
 
-void grid_block::append_columns(long int n)
+void grid_block::append_columns(long int n) noexcept
 {
     blocks_.resize(boost::extents[blocks_.shape()[0]][blocks_.shape()[1] + n]);
 }
 
-void grid_block::append_row()
+void grid_block::append_row() noexcept
 {
     append_rows(1);
 }
 
-void grid_block::append_column()
+void grid_block::append_column() noexcept
 {
     append_columns(1);
 }
 
-long int grid_block::rows() const
+long int grid_block::rows() const noexcept
 {
     return blocks_.shape()[0];
 }
 
-long int grid_block::cols() const
+long int grid_block::cols() const noexcept
 {
     return blocks_.shape()[1];
 }
@@ -81,6 +82,7 @@ void grid_block::render(form& output_form, const style& s) const
 }
 
 std::array<long int, 2> grid_block::extent(const target_info& output_target, const style& s) const
+    noexcept
 {
     std::vector<long int> row_heights;
     std::vector<long int> column_widths;
@@ -94,7 +96,7 @@ std::array<long int, 2> grid_block::extent(const target_info& output_target, con
 }
 
 std::tuple<std::vector<long int>, std::vector<long int>>
-grid_block::compute_layout(const target_info& output_target, const style& s) const
+grid_block::compute_layout(const target_info& output_target, const style& s) const noexcept
 {
     std::vector<long int> row_heights(blocks_.shape()[0]);
     std::vector<long int> column_widths(blocks_.shape()[1]);
@@ -113,7 +115,7 @@ grid_block::compute_layout(const target_info& output_target, const style& s) con
     return std::make_tuple(row_heights, column_widths);
 }
 
-grid_block make_grid(long int rows, long int columns)
+grid_block make_grid(long int rows, long int columns) noexcept
 {
     return grid_block(rows, columns);
 }

--- a/src/indent_block.cpp
+++ b/src/indent_block.cpp
@@ -8,18 +8,19 @@
 #include <carrot/form_view.hpp>
 #include <carrot/style.hpp>
 
+#include <exception>
 #include <utility>
 
 namespace carrot
 {
 
-indent_block::indent_block(block indented_block_, long int indent_levels_)
+indent_block::indent_block(block indented_block_, long int indent_levels_) noexcept
 : indent_block(std::move(indented_block_), indent_levels_, {})
 {
 }
 
 indent_block::indent_block(block indented_block_, long int indent_levels_,
-                           std::vector<std::string> tags_)
+                           std::vector<std::string> tags_) noexcept
 : block_base<indent_block>(std::move(tags_)),
   indented_block_(std::move(indented_block_)),
   indent_levels_(indent_levels_)
@@ -36,26 +37,35 @@ void indent_block::render(form& output_form, const style& s) const
 }
 
 std::array<long int, 2> indent_block::extent(const target_info& output_target, const style& s) const
+    noexcept
 {
-    auto indent = s.get_attribute<style::integer>("indent", id(), tags(), "indent");
+    try
+    {
+        auto indent = s.get_attribute<style::integer>("indent", id(), tags(), "indent");
 
-    auto extent = indented_block_.extent(output_target, s);
+        auto extent = indented_block_.extent(output_target, s);
 
-    return std::array<long int, 2>{extent[0], extent[1] + indent * indent_levels_};
+        return std::array<long int, 2>{extent[0], extent[1] + indent * indent_levels_};
+    }
+    catch (const std::exception&)
+    {
+        std::terminate();
+    }
 }
 
-indent_block indent(block indented_block, long int indent_levels)
+indent_block indent(block indented_block, long int indent_levels) noexcept
 {
     return indent_block(std::move(indented_block), indent_levels);
 }
 
-indent_block indent(block indented_block, std::vector<std::string> tags)
+indent_block indent(block indented_block, std::vector<std::string> tags) noexcept
 {
     return indent(std::move(indented_block), 1, std::move(tags));
 }
 
-indent_block indent(block indented_block, long int indent_levels, std::vector<std::string> tags)
+indent_block indent(block indented_block, long int indent_levels,
+                    std::vector<std::string> tags) noexcept
 {
     return indent_block(std::move(indented_block), indent_levels, std::move(tags));
 }
-}
+} // namespace carrot

--- a/src/irregular_grid_block.cpp
+++ b/src/irregular_grid_block.cpp
@@ -12,7 +12,7 @@
 namespace carrot
 {
 
-void irregular_grid_block::row::render(form & output_form, const style& s) const
+void irregular_grid_block::row::render(form& output_form, const style& s) const
 {
     long int column_offset = 0;
 
@@ -28,7 +28,8 @@ void irregular_grid_block::row::render(form & output_form, const style& s) const
     }
 }
 
-std::array<long int, 2> irregular_grid_block::row::extent(const target_info& output_target, const style& s) const
+std::array<long int, 2> irregular_grid_block::row::extent(const target_info& output_target,
+                                                          const style& s) const noexcept
 {
     std::array<long int, 2> result{0, 0};
 
@@ -43,12 +44,12 @@ std::array<long int, 2> irregular_grid_block::row::extent(const target_info& out
     return result;
 }
 
-void irregular_grid_block::row::append(block element)
+void irregular_grid_block::row::append(block element) noexcept
 {
     elements_.push_back(std::move(element));
 }
 
-void irregular_grid_block::add_to_row(long int row, block element)
+void irregular_grid_block::add_to_row(long int row, block element) noexcept
 {
     rows_.resize(std::max(static_cast<std::size_t>(row + 1), rows_.size()));
 
@@ -71,7 +72,8 @@ void irregular_grid_block::render(form& output_form, const style& s) const
     }
 }
 
-std::array<long int, 2> irregular_grid_block::extent(const target_info& output_target, const style& s) const
+std::array<long int, 2> irregular_grid_block::extent(const target_info& output_target,
+                                                     const style& s) const noexcept
 {
     std::array<long int, 2> result{0, 0};
 
@@ -86,8 +88,8 @@ std::array<long int, 2> irregular_grid_block::extent(const target_info& output_t
     return result;
 }
 
-irregular_grid_block make_irregular_grid()
+irregular_grid_block make_irregular_grid() noexcept
 {
     return irregular_grid_block();
 }
-}
+} // namespace carrot

--- a/src/line_block.cpp
+++ b/src/line_block.cpp
@@ -13,11 +13,11 @@
 namespace carrot
 {
 
-line_block::line_block(growth_direction direction_) : direction_(direction_)
+line_block::line_block(growth_direction direction_) noexcept : direction_(direction_)
 {
 }
 
-line_block& line_block::add(block b)
+line_block& line_block::add(block b) noexcept
 {
     blocks_.push_back(std::move(b));
 
@@ -34,27 +34,28 @@ void line_block::render(form& output_form, const style& s) const
 
         switch (direction_)
         {
-            case growth_direction::right:
-            {
-                form_view view(output_form, 0, offset);
-                block.render(view, s);
+        case growth_direction::right:
+        {
+            form_view view(output_form, 0, offset);
+            block.render(view, s);
 
-                offset += extent[1];
-                break;
-            }
-            case growth_direction::down:
-            {
-                form_view view(output_form, offset, 0);
-                block.render(view, s);
+            offset += extent[1];
+            break;
+        }
+        case growth_direction::down:
+        {
+            form_view view(output_form, offset, 0);
+            block.render(view, s);
 
-                offset += extent[0];
-                break;
-            }
+            offset += extent[0];
+            break;
+        }
         }
     }
 }
 
 std::array<long int, 2> line_block::extent(const target_info& output_target, const style& s) const
+    noexcept
 {
     std::array<long int, 2> result{0, 0};
 
@@ -78,8 +79,8 @@ std::array<long int, 2> line_block::extent(const target_info& output_target, con
     return result;
 }
 
-line_block make_line(growth_direction direction)
+line_block make_line(growth_direction direction) noexcept
 {
     return line_block(direction);
 }
-}
+} // namespace carrot

--- a/src/list_block.cpp
+++ b/src/list_block.cpp
@@ -11,12 +11,11 @@
 
 namespace carrot
 {
-list_block::list_block()
-: grid_(0, 2)
+list_block::list_block() noexcept : grid_(0, 2)
 {
 }
 
-list_block& list_block::add(block b)
+list_block& list_block::add(block b) noexcept
 {
     grid_.append_row();
 
@@ -32,12 +31,13 @@ void list_block::render(form& output_form, const style& s) const
 }
 
 std::array<long int, 2> list_block::extent(const target_info& output_target, const style& s) const
+    noexcept
 {
     return grid_.extent(output_target, s);
 }
 
-list_block make_list()
+list_block make_list() noexcept
 {
     return list_block();
 }
-}
+} // namespace carrot

--- a/src/placeholder_block.cpp
+++ b/src/placeholder_block.cpp
@@ -12,13 +12,14 @@
 #include "grapheme_cluster_view.hpp"
 #endif
 
+#include <exception>
 #include <iterator>
 #include <utility>
 
 namespace carrot
 {
 
-placeholder_block::placeholder_block(std::vector<std::string> tags_)
+placeholder_block::placeholder_block(std::vector<std::string> tags_) noexcept
 : block_base<placeholder_block>(std::move(tags_))
 {
 }
@@ -48,26 +49,33 @@ void placeholder_block::render(form& output_form, const style& s) const
 }
 
 std::array<long int, 2> placeholder_block::extent(const target_info& output_target,
-                                                  const style& s) const
+                                                  const style& s) const noexcept
 {
-    auto content = s.get_attribute<std::string>("placeholder", id(), tags(), "content");
+    try
+    {
+        auto content = s.get_attribute<std::string>("placeholder", id(), tags(), "content");
 
 #ifdef CARROT_WITH_UNICODE_SUPPORT
-    grapheme_cluster_view gc_view(content, output_target.locale());
+        grapheme_cluster_view gc_view(content, output_target.locale());
 
-    auto first = gc_view.begin();
-    auto last = gc_view.end();
+        auto first = gc_view.begin();
+        auto last = gc_view.end();
 #else
-    auto first = content.begin();
-    auto last = content.end();
+        auto first = content.begin();
+        auto last = content.end();
 #endif
 
-    auto width = integer_cast<long int>(distance(first, last));
+        auto width = integer_cast<long int>(distance(first, last));
 
-    return std::array<long int, 2>{1, width};
+        return std::array<long int, 2>{1, width};
+    }
+    catch (const std::exception&)
+    {
+        std::terminate();
+    }
 }
 
-placeholder_block placeholder(std::vector<std::string> tags)
+placeholder_block placeholder(std::vector<std::string> tags) noexcept
 {
     return placeholder_block(std::move(tags));
 }

--- a/src/plain_form.cpp
+++ b/src/plain_form.cpp
@@ -28,7 +28,7 @@ struct color_escape_sequence
 
 color_escape_sequence get_escape_sequence_for_color(const color& foreground_color,
                                                     const color& background_color,
-                                                    const color_map& cmap)
+                                                    const color_map& cmap) noexcept
 {
     const std::size_t foreground_color_escape_sequence = [&foreground_color, &cmap] {
         if (is_default_color(foreground_color))
@@ -79,7 +79,7 @@ color_escape_sequence get_escape_sequence_for_color(const color& foreground_colo
     return {foreground_color_escape_sequence, background_color_escape_sequence};
 }
 
-constexpr std::size_t get_escape_sequence_for_formatting(bool bold)
+constexpr std::size_t get_escape_sequence_for_formatting(bool bold) noexcept
 {
     constexpr std::size_t default_escape_sequence = 22;
     constexpr std::size_t bold_escape_sequence = 1;
@@ -109,7 +109,7 @@ bool operator!=(const terminal_escape_sequence& lhs, const terminal_escape_seque
     return !(lhs == rhs);
 }
 
-std::string render_escape_sequence(const terminal_escape_sequence& escape_sequence)
+std::string render_escape_sequence(const terminal_escape_sequence& escape_sequence) noexcept
 {
     using namespace std::string_view_literals;
 
@@ -121,7 +121,7 @@ std::string render_escape_sequence(const terminal_escape_sequence& escape_sequen
 
 terminal_escape_sequence get_escape_sequences_for_style(const color& foreground_color,
                                                         const color& background_color, bool bold,
-                                                        const color_map& cmap)
+                                                        const color_map& cmap) noexcept
 {
     const auto [foreground_color_escape_sequence, background_color_escape_sequence] =
         get_escape_sequence_for_color(foreground_color, background_color, cmap);
@@ -131,7 +131,7 @@ terminal_escape_sequence get_escape_sequences_for_style(const color& foreground_
             formatting_escape_sequence};
 }
 
-constexpr std::string_view get_default_escape_sequence()
+constexpr std::string_view get_default_escape_sequence() noexcept
 {
     using namespace std::string_view_literals;
 
@@ -139,7 +139,7 @@ constexpr std::string_view get_default_escape_sequence()
 }
 } // namespace
 
-plain_form::plain_form(target_info target_, long int rows_, long int columns_)
+plain_form::plain_form(target_info target_, long int rows_, long int columns_) noexcept
 : target_(std::move(target_)), data_(boost::extents[rows_][columns_]), clear_glyph_(' ')
 {
 }
@@ -151,7 +151,7 @@ void plain_form::set(long int row, long int column, glyph value)
     data_[row][column] = value;
 }
 
-const target_info& plain_form::target() const
+const target_info& plain_form::target() const noexcept
 {
     return target_;
 }
@@ -233,7 +233,7 @@ std::string plain_form::to_string() const
     return result;
 }
 
-void plain_form::clear()
+void plain_form::clear() noexcept
 {
     for (long int row = 0; row < data_.shape()[0]; ++row)
     {
@@ -244,14 +244,14 @@ void plain_form::clear()
     }
 }
 
-void plain_form::clear(glyph value)
+void plain_form::clear(glyph value) noexcept
 {
     clear_glyph_ = std::move(value);
 
     clear();
 }
 
-void plain_form::resize_if_outside_matrix(long int row, long int column)
+void plain_form::resize_if_outside_matrix(long int row, long int column) noexcept
 {
     if (row >= data_.shape()[0] || column >= data_.shape()[1])
     {

--- a/src/progress_bar_block.cpp
+++ b/src/progress_bar_block.cpp
@@ -10,7 +10,7 @@
 namespace carrot
 {
 
-progress_bar_block::progress_bar_block(long int progress_)
+progress_bar_block::progress_bar_block(long int progress_) noexcept
 : text_(std::string(progress_, '+'))
 {
 }
@@ -20,13 +20,14 @@ void progress_bar_block::render(form& output_form, const style& s) const
     text_.render(output_form, s);
 }
 
-std::array<long int, 2> progress_bar_block::extent(const target_info& output_target, const style& s) const
+std::array<long int, 2> progress_bar_block::extent(const target_info& output_target,
+                                                   const style& s) const noexcept
 {
     return text_.extent(output_target, s);
 }
 
-progress_bar_block progress_bar(long int progress)
+progress_bar_block progress_bar(long int progress) noexcept
 {
     return progress_bar_block(progress);
 }
-}
+} // namespace carrot

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -18,7 +18,7 @@ style_rule::selector_type::pattern::pattern(std::string pattern_)
     }
 }
 
-bool style_rule::selector_type::pattern::does_match(std::string_view value) const
+bool style_rule::selector_type::pattern::does_match(std::string_view value) const noexcept
 {
     if (pattern_)
     {
@@ -34,7 +34,7 @@ style_rule::selector_type::selector_type(std::string element_id_, std::string id
 }
 
 bool style_rule::selector_type::does_match(std::string_view element_id, std::string_view id,
-                                           const std::vector<std::string>& tags) const
+                                           const std::vector<std::string>& tags) const noexcept
 {
     if (!element_id_.does_match(element_id))
         return false;
@@ -57,6 +57,7 @@ style_rule::style_rule(std::string element_id_, std::string id_, std::string tag
 }
 
 std::optional<style_rule::attribute> style_rule::get_attribute(std::string_view attribute_id) const
+    noexcept
 {
     auto search_result =
         std::find_if(attributes_.begin(), attributes_.end(),
@@ -99,24 +100,25 @@ style::attribute user_defined_style::get_attribute(std::string_view element_id, 
     throw missing_style_info_error();
 }
 
-style_rule& user_defined_style::add_rule(std::string element_id)
+style_rule& user_defined_style::add_rule(std::string element_id) noexcept
 {
     return add_rule(std::move(element_id), "*");
 }
 
-style_rule& user_defined_style::add_rule(std::string element_id, std::string tag)
+style_rule& user_defined_style::add_rule(std::string element_id, std::string tag) noexcept
 {
     return add_rule(std::move(element_id), std::move(tag), "*");
 }
 
-style_rule& user_defined_style::add_rule(std::string element_id, std::string tag, std::string id)
+style_rule& user_defined_style::add_rule(std::string element_id, std::string tag,
+                                         std::string id) noexcept
 {
     rules_.emplace_back(std::move(element_id), std::move(id), std::move(tag));
 
     return rules_.back();
 }
 
-augmented_style::augmented_style(const style& base_style_) : base_style_(&base_style_)
+augmented_style::augmented_style(const style& base_style_) noexcept : base_style_(&base_style_)
 {
 }
 
@@ -139,24 +141,25 @@ style::attribute augmented_style::get_attribute(std::string_view element_id, std
     throw missing_style_info_error();
 }
 
-style_rule& augmented_style::add_rule(std::string element_id)
+style_rule& augmented_style::add_rule(std::string element_id) noexcept
 {
     return add_rule(std::move(element_id), "*");
 }
 
-style_rule& augmented_style::add_rule(std::string element_id, std::string tag)
+style_rule& augmented_style::add_rule(std::string element_id, std::string tag) noexcept
 {
     return add_rule(std::move(element_id), std::move(tag), "*");
 }
 
-style_rule& augmented_style::add_rule(std::string element_id, std::string tag, std::string id)
+style_rule& augmented_style::add_rule(std::string element_id, std::string tag,
+                                      std::string id) noexcept
 {
     rules_.emplace_back(std::move(element_id), std::move(id), std::move(tag));
 
     return rules_.back();
 }
 
-std::unique_ptr<style> get_default_style()
+std::unique_ptr<style> get_default_style() noexcept
 {
     static constexpr short hightest_color_value = 255;
     static constexpr short lowest_color_value = 0;

--- a/src/table_block.cpp
+++ b/src/table_block.cpp
@@ -12,14 +12,28 @@
 namespace carrot
 {
 
-invalid_number_of_columns_error::invalid_number_of_columns_error(long int expected,
-                                                                 long int provided)
-: std::logic_error("Expected " + std::to_string(expected) + " columns but received " +
-                   std::to_string(provided) + ".")
+namespace
 {
+/** @brief The exception thrown if the number of column provided is invalid.
+ */
+class CARROT_EXPORT invalid_number_of_columns_error final : public runtime_error
+{
+public:
+    /** @brief Constructs a new exception.
+     *
+     * @param expected The expected number of columns.
+     * @param provided The actually provided number of columns.
+     */
+    explicit invalid_number_of_columns_error(long int expected, long int provided) noexcept
+        : runtime_error("Expected " + std::to_string(expected) + " columns but received " +
+                           std::to_string(provided) + ".")
+    {
+    }
+};
 }
 
-table_block::table_block(long int columns_) : grid_(0, 2 * columns_ - 1), columns_(columns_)
+table_block::table_block(long int columns_) noexcept
+: grid_(0, 2 * columns_ - 1), columns_(columns_)
 {
 }
 
@@ -54,12 +68,13 @@ void table_block::render(form& output_form, const style& s) const
 }
 
 std::array<long int, 2> table_block::extent(const target_info& output_target, const style& s) const
+    noexcept
 {
     return grid_.extent(output_target, s);
 }
 
-table_block make_table(long int columns)
+table_block make_table(long int columns) noexcept
 {
     return table_block(columns);
 }
-}
+} // namespace carrot

--- a/src/target_info.cpp
+++ b/src/target_info.cpp
@@ -35,7 +35,7 @@ namespace
 std::mutex term_mutex;
 #endif
 
-bool terminal_has_colors(int fd)
+bool terminal_has_colors(int fd) noexcept
 {
 #ifdef HAVE_TERMINFO
     std::lock_guard<std::mutex> guard(term_mutex);
@@ -58,7 +58,7 @@ bool terminal_has_colors(int fd)
 #endif
 }
 
-bool has_color_support(int fd)
+bool has_color_support(int fd) noexcept
 {
 #ifdef __unix__
     bool is_a_tty = isatty(fd) > 0;
@@ -72,45 +72,45 @@ bool has_color_support(int fd)
 } // namespace
 
 invalid_target_error::invalid_target_error(const std::string& reason_)
-: std::logic_error("Invalid target: " + reason_)
+: runtime_error("Invalid target: " + reason_)
 {
 }
 
 target_info::target_info(const std::locale& locale_, bool supports_colorized_output_,
-                         long int tab_width_)
+                         long int tab_width_) noexcept
 : locale_(locale_), supports_colorized_output_(supports_colorized_output_), tab_width_(tab_width_)
 {
 }
 
-bool target_info::supports_colorized_output() const
+bool target_info::supports_colorized_output() const noexcept
 {
     return supports_colorized_output_;
 }
 
-long int target_info::tab_width() const
+long int target_info::tab_width() const noexcept
 {
     return tab_width_;
 }
 
-const std::locale& target_info::locale() const
+const std::locale& target_info::locale() const noexcept
 {
     return locale_;
 }
 
 namespace
 {
-std::locale get_default_locale()
+std::locale get_default_locale() noexcept
 {
     return std::locale("");
 }
 } // namespace
 
-target_info get_stdout_target(long int tab_width)
+target_info get_stdout_target(long int tab_width) noexcept
 {
     return get_stdout_target(get_default_locale(), tab_width);
 }
 
-target_info get_stdout_target(const std::locale& locale, long int tab_width)
+target_info get_stdout_target(const std::locale& locale, long int tab_width) noexcept
 {
 #ifdef __unix__
     bool colorize_output = has_color_support(STDOUT_FILENO);
@@ -120,22 +120,22 @@ target_info get_stdout_target(const std::locale& locale, long int tab_width)
     return target_info(locale, colorize_output, tab_width);
 }
 
-target_info get_file_target(long int tab_width)
+target_info get_file_target(long int tab_width) noexcept
 {
     return get_file_target(get_default_locale(), tab_width);
 }
 
-target_info get_file_target(const std::locale& locale, long int tab_width)
+target_info get_file_target(const std::locale& locale, long int tab_width) noexcept
 {
     return target_info(locale, false, tab_width);
 }
 
-target_info get_colorized_target(long int tab_width)
+target_info get_colorized_target(long int tab_width) noexcept
 {
     return get_colorized_target(get_default_locale(), tab_width);
 }
 
-target_info get_colorized_target(const std::locale& locale, long int tab_width)
+target_info get_colorized_target(const std::locale& locale, long int tab_width) noexcept
 {
     return target_info(locale, true, tab_width);
 }

--- a/src/text_block.cpp
+++ b/src/text_block.cpp
@@ -26,11 +26,11 @@
 namespace carrot
 {
 
-text_block::text_block(std::string_view content_) : text_block(content_, {})
+text_block::text_block(std::string_view content_) noexcept : text_block(content_, {})
 {
 }
 
-text_block::text_block(std::string_view content_, std::vector<std::string> tags_)
+text_block::text_block(std::string_view content_, std::vector<std::string> tags_) noexcept
 : block_base<text_block>(std::move(tags_))
 {
     boost::split(rows_, content_, boost::is_any_of("\n"));
@@ -70,11 +70,12 @@ class get_row_length
 public:
     using result_type = long int;
 
-    explicit get_row_length(const target_info& output_target_) : output_target_(&output_target_)
+    explicit get_row_length(const target_info& output_target_) noexcept
+    : output_target_(&output_target_)
     {
     }
 
-    result_type operator()(const std::string& value) const
+    result_type operator()(const std::string& value) const noexcept
     {
         assert(output_target_ != nullptr);
 
@@ -97,7 +98,7 @@ private:
 } // namespace
 
 std::array<long int, 2> text_block::extent(const target_info& output_target,
-                                           const style& s [[maybe_unused]]) const
+                                           const style& s [[maybe_unused]]) const noexcept
 {
     long int rows = rows_.size();
 
@@ -110,12 +111,12 @@ std::array<long int, 2> text_block::extent(const target_info& output_target,
     return std::array<long int, 2>{rows, columns};
 }
 
-text_block text(std::string_view content)
+text_block text(std::string_view content) noexcept
 {
     return text_block(content);
 }
 
-text_block text(std::string_view content, std::vector<std::string> flags)
+text_block text(std::string_view content, std::vector<std::string> flags) noexcept
 {
     return text_block(content, std::move(flags));
 }

--- a/src/underline_block.cpp
+++ b/src/underline_block.cpp
@@ -10,12 +10,12 @@
 namespace carrot
 {
 
-underline_block::underline_block(block underlined_element_)
+underline_block::underline_block(block underlined_element_) noexcept
 : underline_block(std::move(underlined_element_), {})
 {
 }
 
-underline_block::underline_block(block underlined_element_, std::vector<std::string> tags_)
+underline_block::underline_block(block underlined_element_, std::vector<std::string> tags_) noexcept
 : block_base<underline_block>(std::move(tags_)), underlined_element_(std::move(underlined_element_))
 {
 }
@@ -32,20 +32,21 @@ void underline_block::render(form& output_form, const style& s) const
     }
 }
 
-std::array<long int, 2> underline_block::extent(const target_info& output_target, const style& s) const
+std::array<long int, 2> underline_block::extent(const target_info& output_target,
+                                                const style& s) const noexcept
 {
     auto extent = underlined_element_.extent(output_target, s);
 
     return std::array<long int, 2>{extent[0] + 1, extent[1]};
 }
 
-underline_block underline(block underlined_element)
+underline_block underline(block underlined_element) noexcept
 {
     return underline_block(std::move(underlined_element));
 }
 
-underline_block underline(block underlined_element, std::vector<std::string> tags)
+underline_block underline(block underlined_element, std::vector<std::string> tags) noexcept
 {
     return underline_block(std::move(underlined_element), std::move(tags));
 }
-}
+} // namespace carrot

--- a/tests/color.cpp
+++ b/tests/color.cpp
@@ -88,7 +88,7 @@ TEST_CASE("Empty color maps are invalid", "[color]")
 
     std::vector<hsl_color> colors;
 
-    REQUIRE_THROWS_AS(color_map(colors), invalid_color_map_error);
+    REQUIRE_THROWS_AS(color_map(colors), runtime_error);
 }
 
 TEST_CASE("Color map initialisation", "[color]")
@@ -142,12 +142,12 @@ TEST_CASE("Named color support", "[color]")
 {
     using namespace carrot;
 
-    REQUIRE_THROWS_AS(rgb(named_color("red")), invalid_color_error);
-    REQUIRE_THROWS_AS(hsl(named_color("red")), invalid_color_error);
+    REQUIRE_THROWS_AS(rgb(named_color("red")), runtime_error);
+    REQUIRE_THROWS_AS(hsl(named_color("red")), runtime_error);
 
     color_table ctable;
 
-    REQUIRE_THROWS_AS(rgb(named_color("red"), ctable), invalid_color_error);
+    REQUIRE_THROWS_AS(rgb(named_color("red"), ctable), runtime_error);
 
     ctable = get_default_color_table();
 
@@ -178,12 +178,12 @@ TEST_CASE("Special default colors", "[color]")
 
     auto ctable = get_default_color_table();
 
-    REQUIRE_THROWS_AS(rgb(get_default_color()), invalid_color_error);
-    REQUIRE_THROWS_AS(rgb(get_default_color(), ctable), invalid_color_error);
-    REQUIRE_THROWS_AS(hsl(get_default_color()), invalid_color_error);
-    REQUIRE_THROWS_AS(hsl(get_default_color(), ctable), invalid_color_error);
+    REQUIRE_THROWS_AS(rgb(get_default_color()), runtime_error);
+    REQUIRE_THROWS_AS(rgb(get_default_color(), ctable), runtime_error);
+    REQUIRE_THROWS_AS(hsl(get_default_color()), runtime_error);
+    REQUIRE_THROWS_AS(hsl(get_default_color(), ctable), runtime_error);
 
-    REQUIRE_THROWS_AS(canonicalize(get_default_color(), ctable), invalid_color_error);
+    REQUIRE_THROWS_AS(canonicalize(get_default_color(), ctable), runtime_error);
 
     REQUIRE(is_default_color(get_default_color()));
 }


### PR DESCRIPTION
In particular, every external function is now
either marked as noexcept or the exceptions it
can throw are documented.

Due to the fact, that we only throw exceptions
on recoverable errors, this means that most
functions are now noexcept. For a few of the
remaining uses of exceptions, it it still debatable
if one can recover from these errors.