### PR TITLE
Verifying more of the implicit integer casts

### DIFF
--- a/src/grid_block.cpp
+++ b/src/grid_block.cpp
@@ -9,6 +9,8 @@
 
 #include <carrot/form_view.hpp>
 
+#include <carrot/integers.hpp>
+
 #include <algorithm>
 #include <utility>
 
@@ -47,12 +49,12 @@ void grid_block::append_column() noexcept
 
 long int grid_block::rows() const noexcept
 {
-    return blocks_.shape()[0];
+    return integer_cast<long int>(blocks_.shape()[0]);
 }
 
 long int grid_block::cols() const noexcept
 {
-    return blocks_.shape()[1];
+    return integer_cast<long int>(blocks_.shape()[1]);
 }
 
 void grid_block::render(form& output_form, const style& s) const

--- a/src/plain_form.cpp
+++ b/src/plain_form.cpp
@@ -7,6 +7,8 @@
 
 #include <carrot/color_map.hpp>
 
+#include <carrot/integers.hpp>
+
 #include <boost/range/adaptor/sliced.hpp>
 
 #include <fmt/format.h>
@@ -167,10 +169,10 @@ std::string plain_form::to_string() const
 
     terminal_escape_sequence current_escape_seq = {};
 
-    for (long int row = 0; row < data_.shape()[0]; ++row)
+    for (long int row = 0; row < integer_cast<long int>(data_.shape()[0]); ++row)
     {
         long int last_significant_column = [&] {
-            long int column = data_.shape()[1];
+            long int column = integer_cast<long int>(data_.shape()[1]);
 
             for (; column-- > 0;)
             {
@@ -235,9 +237,9 @@ std::string plain_form::to_string() const
 
 void plain_form::clear() noexcept
 {
-    for (long int row = 0; row < data_.shape()[0]; ++row)
+    for (long int row = 0; row < integer_cast<long int>(data_.shape()[0]); ++row)
     {
-        for (long int column = 0; column < data_.shape()[1]; ++column)
+        for (long int column = 0; column < integer_cast<long int>(data_.shape()[1]); ++column)
         {
             data_[row][column] = clear_glyph_;
         }

--- a/src/text_block.cpp
+++ b/src/text_block.cpp
@@ -100,7 +100,7 @@ private:
 std::array<long int, 2> text_block::extent(const target_info& output_target,
                                            const style& s [[maybe_unused]]) const noexcept
 {
-    long int rows = rows_.size();
+    long int rows = integer_cast<long int>(rows_.size());
 
     auto row_lenghts = rows_ | boost::adaptors::transformed(get_row_length(output_target));
 


### PR DESCRIPTION
Previously, we would cast without any checks.
This PR adds proper debug checks via
carrot's integer utilities.

This also resolves the warnings which were
emitted by both compilers and static analysis
tools.